### PR TITLE
BetterDefaultHandling

### DIFF
--- a/service/settings.py
+++ b/service/settings.py
@@ -50,12 +50,15 @@ class SettingsProvider(object):
             p = config.parsePath(self.BASE_PATH, area)
 
             if os.path.exists(p):
+                # noinspection PyBroadException
                 try:
                     f = open(p, "rb")
                     info = cPickle.load(f)
                 except:
                     info = {}
                     # TODO: Add logging message that we failed to open the file
+            else:
+                info = {}
 
             s = Settings(p, info)
 
@@ -140,18 +143,18 @@ class NetworkSettings(object):
         self.serviceNetworkSettings = SettingsProvider.getInstance().getSettings(
             "pyfaServiceNetworkSettings", serviceNetworkDefaultSettings)
 
-    def isEnabled(self, type):
-        if type & self.serviceNetworkSettings["access"]:
+    def isEnabled(self, setting_type):
+        if setting_type & self.serviceNetworkSettings["access"]:
             return True
         return False
 
-    def toggleAccess(self, type, toggle=True):
+    def toggleAccess(self, setting_type, toggle=True):
         bitfield = self.serviceNetworkSettings["access"]
 
         if toggle:  # Turn bit on
-            self.serviceNetworkSettings["access"] = type | bitfield
+            self.serviceNetworkSettings["access"] = setting_type | bitfield
         else:  # Turn bit off
-            self.serviceNetworkSettings["access"] = ~type & bitfield
+            self.serviceNetworkSettings["access"] = ~setting_type & bitfield
 
     def getMode(self):
         return self.serviceNetworkSettings["mode"]
@@ -177,8 +180,8 @@ class NetworkSettings(object):
     def setPort(self, port):
         self.serviceNetworkSettings["port"] = port
 
-    def setType(self, type):
-        self.serviceNetworkSettings["type"] = type
+    def setType(self, setting_type):
+        self.serviceNetworkSettings["type"] = setting_type
 
     def setAccess(self, access):
         self.serviceNetworkSettings["access"] = access
@@ -302,11 +305,11 @@ class UpdateSettings(object):
             serviceUpdateDefaultSettings
         )
 
-    def get(self, type):
-        return self.serviceUpdateSettings[type]
+    def get(self, setting_type):
+        return self.serviceUpdateSettings[setting_type]
 
-    def set(self, type, value):
-        self.serviceUpdateSettings[type] = value
+    def set(self, setting_type, value):
+        self.serviceUpdateSettings[setting_type] = value
 
 
 class CRESTSettings(object):
@@ -330,10 +333,10 @@ class CRESTSettings(object):
             serviceCRESTDefaultSettings
         )
 
-    def get(self, type):
-        return self.serviceCRESTSettings[type]
+    def get(self, setting_type):
+        return self.serviceCRESTSettings[setting_type]
 
-    def set(self, type, value):
-        self.serviceCRESTSettings[type] = value
+    def set(self, setting_type, value):
+        self.serviceCRESTSettings[setting_type] = value
 
 # @todo: migrate fit settings (from fit service) here?

--- a/service/settings.py
+++ b/service/settings.py
@@ -42,31 +42,26 @@ class SettingsProvider(object):
 
     def getSettings(self, area, defaults=None):
 
+        if defaults is None:
+            defaults = []
+
         s = self.settings.get(area)
         if s is None:
             p = config.parsePath(self.BASE_PATH, area)
 
-            if not os.path.exists(p):
-                info = {}
-                if defaults:
-                    for item in defaults:
-                        info[item] = defaults[item]
-
-            else:
+            if os.path.exists(p):
                 try:
                     f = open(p, "rb")
                     info = cPickle.load(f)
-                    for item in defaults:
-                        if item not in info:
-                            info[item] = defaults[item]
-
                 except:
                     info = {}
-                    if defaults:
-                        for item in defaults:
-                            info[item] = defaults[item]
+                    # TODO: Add logging message that we failed to open the file
 
-            self.settings[area] = s = Settings(p, info)
+            s = Settings(p, info)
+
+        for item in defaults:
+            if item not in s.info:
+                s.info[item] = defaults[item]
 
         return s
 


### PR DESCRIPTION
In current branches (Dev/Master), there's a bug that requires us to have default values. But sometimes you don't want to have to have defaults for settings, it might not make sense to set them, or they might be variable, or the defaults might be set elsewhere (think column widths).

So, lets not force you to have defaults. :)

Also, we don't need to try and inject defaults 3 times, that's silly. Lets make that a little simpler.

Additionally, if you added a default down the road (after the settings file was created), it wouldn't get added to the settings.  So lets go ahead and allow for that scenario.