### PR TITLE
Catch missing fit

### DIFF
--- a/eos/modifiedAttributeDict.py
+++ b/eos/modifiedAttributeDict.py
@@ -356,7 +356,7 @@ class ModifiedAttributeDict(collections.MutableMapping):
         if skill:
             boostFactor *= self.__handleSkill(skill)
 
-        if remoteResists:
+        if remoteResists and self.fit:
             # @todo: this is such a disgusting hack. Look into sending these checks to the module class before the
             # effect is applied.
             mod = self.fit.getModifier()


### PR DESCRIPTION
Have seen this before but we weren't catching it (error window catches it now).

When we are projecting onto self, we can't get remote resists because the fit object doesn't exist. Remote resistance is an ugly hack, so just skip it if we're missing the fit for now.