### PR TITLE
Fix for Gnosis and Effects

### DIFF
--- a/eos/db/saveddata/queries.py
+++ b/eos/db/saveddata/queries.py
@@ -34,6 +34,12 @@ from eos.saveddata.module import Module
 from eos.saveddata.miscData import MiscData
 from eos.saveddata.override import Override
 
+'''
+from eos.db.saveddata import fit as es_fit
+from eos.db.saveddata.fit import fits_table, fighters_table, fitImplants_table, commandFits_table
+from eos.db.saveddata.module import modules_table
+'''
+
 import eos.config
 
 configVal = getattr(eos.config, "saveddataCache", None)

--- a/eos/saveddata/drone.py
+++ b/eos/saveddata/drone.py
@@ -159,6 +159,18 @@ class Drone(HandledItem, HandledCharge, ItemAttrShortcut, ChargeAttrShortcut):
         return self.__miningyield
 
     @property
+    def cycleTime(self):
+        return self.rawCycleTime
+
+    @property
+    def rawCycleTime(self):
+        speed = max(
+                self.getModifiedItemAttr("duration"),  # Most drones
+                0,  # Return 0 if none of the above are valid
+        )
+        return speed
+
+    @property
     def maxRange(self):
         attrs = ("shieldTransferRange", "powerTransferRange",
                  "energyDestabilizationRange", "empFieldRange",


### PR DESCRIPTION
Tripped by the refactor to standardize property used.

Gnosis requires `rawCycleTime`, and effects require `cycleTime`.  Add both of these into drones, making them even more standard!