### PR TITLE
Unicode for file paths

### DIFF
--- a/_development/helpers.py
+++ b/_development/helpers.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import sessionmaker
 
 script_dir = os.path.dirname(os.path.abspath(__file__))
 # Add root folder to python paths
-sys.path.append(os.path.realpath(os.path.join(script_dir, '..', '..')))
+sys.path.append(os.path.realpath(os.path.join(script_dir, u'..', u'..')))
 sys._called_from_test = True
 
 

--- a/config.py
+++ b/config.py
@@ -100,15 +100,18 @@ def defPaths(customSavePath):
 
 
 def getPyfaPath(Append=None):
+    print("-----------")
     print(str(sys.argv[0]))
     print(str(__file__))
     print(str(os.getcwd()))
     print("-----------")
     print(str(os.path.dirname(os.path.realpath(sys.argv[0]))))
     print(str(os.path.dirname(os.path.realpath(__file__))))
+    print("-----------")
 
     # base = os.getcwd()
-    base = sys.argv[0]
+    # base = sys.argv[0]
+    base = __file__
 
     try:
         base = unicode(base)

--- a/config.py
+++ b/config.py
@@ -158,24 +158,25 @@ def getSavePath(Append=None):
 
 
 class GUID(ctypes.Structure):
-    _fields_ = [
-         ('Data1', wintypes.DWORD),
-         ('Data2', wintypes.WORD),
-         ('Data3', wintypes.WORD),
-         ('Data4', wintypes.BYTE * 8)
-    ]
+    if wintypes:
+        _fields_ = [
+             ('Data1', wintypes.DWORD),
+             ('Data2', wintypes.WORD),
+             ('Data3', wintypes.WORD),
+             ('Data4', wintypes.BYTE * 8)
+        ]
 
-    def __init__(self, l, w1, w2, b1, b2, b3, b4, b5, b6, b7, b8):
-        """Create a new GUID."""
-        self.Data1 = l
-        self.Data2 = w1
-        self.Data3 = w2
-        self.Data4[:] = (b1, b2, b3, b4, b5, b6, b7, b8)
+        def __init__(self, l, w1, w2, b1, b2, b3, b4, b5, b6, b7, b8):
+            """Create a new GUID."""
+            self.Data1 = l
+            self.Data2 = w1
+            self.Data3 = w2
+            self.Data4[:] = (b1, b2, b3, b4, b5, b6, b7, b8)
 
-    def __repr__(self):
-        b1, b2, b3, b4, b5, b6, b7, b8 = self.Data4
-        return 'GUID(%x-%x-%x-%x%x%x%x%x%x%x%x)' % (
-                   self.Data1, self.Data2, self.Data3, b1, b2, b3, b4, b5, b6, b7, b8)
+        def __repr__(self):
+            b1, b2, b3, b4, b5, b6, b7, b8 = self.Data4
+            return 'GUID(%x-%x-%x-%x%x%x%x%x%x%x%x)' % (
+                       self.Data1, self.Data2, self.Data3, b1, b2, b3, b4, b5, b6, b7, b8)
 
 
 def expand_user():
@@ -191,17 +192,18 @@ def expand_user():
     CSIDL_PROFILE = 40
     FOLDERID_Profile = GUID(0x5E6C858F, 0x0E22, 0x4760, 0x9A, 0xFE, 0xEA, 0x33, 0x17, 0xB6, 0x71, 0x73)
 
-    # get the function that we can find from Vista up, not the one in XP
-    get_folder_path = getattr(windll.shell32, 'SHGetKnownFolderPath', None)
+    if windll:
+        # get the function that we can find from Vista up, not the one in XP
+        get_folder_path = getattr(windll.shell32, 'SHGetKnownFolderPath', None)
 
-    if get_folder_path is not None:
-        # ok, we can use the new function which is recomended by the msdn
-        ptr = ctypes.c_wchar_p()
-        get_folder_path(ctypes.byref(FOLDERID_Profile), 0, 0, ctypes.byref(ptr))
-        return ptr.value
-    else:
-        # use the deprecated one found in XP and on for compatibility reasons
-        get_folder_path = getattr(windll.shell32, 'SHGetSpecialFolderPathW', None)
-        buf = ctypes.create_unicode_buffer(300)
-        get_folder_path(None, buf, CSIDL_PROFILE, False)
-        return buf.value
+        if get_folder_path is not None:
+            # ok, we can use the new function which is recomended by the msdn
+            ptr = ctypes.c_wchar_p()
+            get_folder_path(ctypes.byref(FOLDERID_Profile), 0, 0, ctypes.byref(ptr))
+            return ptr.value
+        else:
+            # use the deprecated one found in XP and on for compatibility reasons
+            get_folder_path = getattr(windll.shell32, 'SHGetSpecialFolderPathW', None)
+            buf = ctypes.create_unicode_buffer(300)
+            get_folder_path(None, buf, CSIDL_PROFILE, False)
+            return buf.value

--- a/config.py
+++ b/config.py
@@ -100,14 +100,22 @@ def defPaths(customSavePath):
 
 
 def getPyfaPath(Append=None):
-    base = os.getcwd()
+    print(str(sys.argv[0]))
+    print(str(__file__))
+    print(str(os.getcwd()))
+    print("-----------")
+    print(str(os.path.dirname(os.path.realpath(sys.argv[0]))))
+    print(str(os.path.dirname(os.path.realpath(__file__))))
+
+    # base = os.getcwd()
+    base = os.path.dirname(os.path.realpath(sys.argv[0]))
 
     try:
         base = unicode(base)
     except:
         base = unicode(base, sys.getfilesystemencoding())
 
-    root = os.path.realpath(os.path.abspath(base))
+    root = os.path.realpath(base)
 
     if not Append:
         return root
@@ -117,7 +125,7 @@ def getPyfaPath(Append=None):
     except:
         Append = unicode(Append, sys.getfilesystemencoding())
 
-    path = os.path.abspath(os.path.join(root, Append))
+    path = os.path.realpath(os.path.join(root, Append))
 
     return path
 
@@ -133,6 +141,6 @@ def getSavePath(Append=None):
     except:
         Append = unicode(Append, sys.getfilesystemencoding())
 
-    path = os.path.abspath(os.path.join(root, Append))
+    path = os.path.realpath(os.path.join(root, Append))
 
     return path

--- a/config.py
+++ b/config.py
@@ -108,12 +108,14 @@ def getPyfaPath(Append=None):
     print(str(os.path.dirname(os.path.realpath(__file__))))
 
     # base = os.getcwd()
-    base = os.path.dirname(os.path.realpath(sys.argv[0]))
+    base = sys.argv[0]
 
     try:
         base = unicode(base)
     except:
         base = unicode(base, sys.getfilesystemencoding())
+
+    base = os.path.dirname(os.path.realpath(base))
 
     root = os.path.realpath(base)
 

--- a/config.py
+++ b/config.py
@@ -100,14 +100,14 @@ def defPaths(customSavePath):
 
 
 def getPyfaPath(Append=None):
-    base = getattr(sys.modules['__main__'], "__file__", sys.executable) if isFrozen() else sys.argv[0]
+    base = os.getcwd()
 
     try:
         base = unicode(base)
     except:
         base = unicode(base, sys.getfilesystemencoding())
 
-    root = os.path.dirname(os.path.realpath(os.path.abspath(base)))
+    root = os.path.realpath(os.path.abspath(base))
 
     if not Append:
         return root

--- a/config.py
+++ b/config.py
@@ -3,12 +3,12 @@ import sys
 import ctypes
 import platform
 
+from logbook import Logger
+
 if platform.system() is "Windows":
     from ctypes import windll, wintypes
 else:
     windll = wintypes = None
-
-from logbook import Logger
 
 pyfalog = Logger(__name__)
 

--- a/config.py
+++ b/config.py
@@ -78,7 +78,7 @@ def defPaths(customSavePath):
     __createDirs(savePath)
 
     if isFrozen():
-        os.environ["REQUESTS_CA_BUNDLE"] =  getPyfaPath(u"cacert.pem")
+        os.environ["REQUESTS_CA_BUNDLE"] = getPyfaPath(u"cacert.pem")
         os.environ["SSL_CERT_FILE"] = getPyfaPath(u"cacert.pem")
 
     # The database where we store all the fits etc

--- a/config.py
+++ b/config.py
@@ -100,27 +100,20 @@ def defPaths(customSavePath):
 
 
 def getPyfaPath(Append=None):
-    print("-----------")
-    print(str(sys.argv[0]))
-    print(str(__file__))
-    print(str(os.getcwd()))
-    print("-----------")
-    print(str(os.path.dirname(os.path.realpath(sys.argv[0]))))
-    print(str(os.path.dirname(os.path.realpath(__file__))))
-    print("-----------")
-
-    # base = os.getcwd()
-    # base = sys.argv[0]
     base = __file__
+    base_alt = sys.argv[0]
 
     try:
         base = unicode(base)
+        base_alt = unicode(base_alt)
     except:
         base = unicode(base, sys.getfilesystemencoding())
+        base_alt = unicode(base_alt, sys.getfilesystemencoding())
 
-    base = os.path.dirname(os.path.realpath(base))
+    root = os.path.dirname(os.path.realpath(base))
 
-    root = os.path.realpath(base)
+    if not os.path.isdir(root):
+        root = os.path.dirname(os.path.realpath(base_alt))
 
     if not Append:
         return root

--- a/config.py
+++ b/config.py
@@ -1,8 +1,12 @@
 import os
 import sys
 import ctypes
-from ctypes import windll, wintypes
 import platform
+
+if platform.system() is "Windows":
+    from ctypes import windll, wintypes
+else:
+    windll = wintypes = None
 
 from logbook import Logger
 

--- a/eos/config.py
+++ b/eos/config.py
@@ -17,7 +17,11 @@ pyfalog.debug("Gamedata connection string: {0}", gamedata_connectionstring)
 if istravis is True or hasattr(sys, '_called_from_test'):
     # Running in Travis. Run saveddata database in memory.
     saveddata_connectionstring = 'sqlite:///:memory:'
-else:
+
+try:
+    saveddata_connectionstring
+except NameError:
+    # Only set this if it hasn't been set elsewhere
     saveddata_connectionstring = 'sqlite:///' + realpath(join(dirname(abspath(__file__)), u"..", u"saveddata", u"saveddata.db"))
 
 pyfalog.debug("Saveddata connection string: {0}", saveddata_connectionstring)

--- a/eos/config.py
+++ b/eos/config.py
@@ -11,14 +11,14 @@ debug = False
 gamedataCache = True
 saveddataCache = True
 gamedata_version = ""
-gamedata_connectionstring = 'sqlite:///' + unicode(realpath(join(dirname(abspath(__file__)), "..", "eve.db")), sys.getfilesystemencoding())
+gamedata_connectionstring = 'sqlite:///' + realpath(join(dirname(abspath(__file__)), u"..", u"eve.db"))
 pyfalog.debug("Gamedata connection string: {0}", gamedata_connectionstring)
 
 if istravis is True or hasattr(sys, '_called_from_test'):
     # Running in Travis. Run saveddata database in memory.
     saveddata_connectionstring = 'sqlite:///:memory:'
 else:
-    saveddata_connectionstring = 'sqlite:///' + unicode(realpath(join(dirname(abspath(__file__)), "..", "saveddata", "saveddata.db")), sys.getfilesystemencoding())
+    saveddata_connectionstring = 'sqlite:///' + realpath(join(dirname(abspath(__file__)), u"..", u"saveddata", u"saveddata.db"))
 
 pyfalog.debug("Saveddata connection string: {0}", saveddata_connectionstring)
 
@@ -28,4 +28,4 @@ settings = {
 }
 
 # Autodetect path, only change if the autodetection bugs out.
-path = dirname(unicode(__file__, sys.getfilesystemencoding()))
+path = dirname(__file__)

--- a/eos/db/__init__.py
+++ b/eos/db/__init__.py
@@ -59,7 +59,7 @@ if config.saveddata_connectionstring is not None:
     saveddata_engine = saveddata_meta.bind = saveddata_factory['Engine']
     saveddata_session = saveddata_factory['Session']
 else:
-    saveddata_meta = None
+    saveddata_session = saveddata_engine = saveddata_meta = None
 
 # Lock controlling any changes introduced to session
 sd_lock = threading.RLock()

--- a/gui/bitmapLoader.py
+++ b/gui/bitmapLoader.py
@@ -25,8 +25,6 @@ from config import getPyfaPath
 # noinspection PyPackageRequirements
 import wx
 
-import config
-
 from logbook import Logger
 
 logging = Logger(__name__)

--- a/gui/bitmapLoader.py
+++ b/gui/bitmapLoader.py
@@ -20,6 +20,7 @@
 import cStringIO
 import os.path
 import zipfile
+from config import getPyfaPath
 
 # noinspection PyPackageRequirements
 import wx
@@ -38,7 +39,7 @@ except ImportError:
 
 class BitmapLoader(object):
     try:
-        archive = zipfile.ZipFile(os.path.join(config.pyfaPath, 'imgs.zip'), 'r')
+        archive = zipfile.ZipFile(getPyfaPath(u'imgs.zip'), 'r')
         logging.info("Using zipped image files.")
     except IOError:
         logging.info("Using local image files.")
@@ -85,7 +86,7 @@ class BitmapLoader(object):
         if cls.archive:
             path = os.path.join(location, filename)
             if os.sep != "/" and os.sep in path:
-                path = path.replace(os.sep, "/")
+                path = path.replace(os.sep, u"/")
 
             try:
                 img_data = cls.archive.read(path)
@@ -94,7 +95,7 @@ class BitmapLoader(object):
             except KeyError:
                 print("Missing icon file from zip: {0}".format(path))
         else:
-            path = os.path.join(config.pyfaPath, 'imgs' + os.sep + location + os.sep + filename)
+            path = getPyfaPath(u'imgs' + os.sep + location + os.sep + filename)
 
             if os.path.exists(path):
                 return wx.Image(path)

--- a/gui/graphFrame.py
+++ b/gui/graphFrame.py
@@ -81,9 +81,9 @@ class GraphFrame(wx.Frame):
         try:
             cache_dir = mpl._get_cachedir()
         except:
-            cache_dir = os.path.expanduser(os.path.join("~", ".matplotlib"))
+            cache_dir = os.path.expanduser(os.path.join(u"~", u".matplotlib"))
 
-        cache_file = os.path.join(cache_dir, 'fontList.cache')
+        cache_file = os.path.join(cache_dir, u'fontList.cache')
 
         if os.access(cache_dir, os.W_OK | os.X_OK) and os.path.isfile(cache_file):
             # remove matplotlib font cache, see #234

--- a/gui/itemStats.py
+++ b/gui/itemStats.py
@@ -858,7 +858,8 @@ class ItemEffects(wx.Panel):
         If effect file does not exist, create it
         """
 
-        file_ = os.path.join(config.pyfaPath, "eos", "effects", "%s.py" % event.GetText().lower())
+        effect_path = os.path.join(u"eos", u"effects", u"%s.py" % event.GetText().lower())
+        file_ = config.getPyfaPath(effect_path)
 
         if not os.path.isfile(file_):
             open(file_, 'a').close()
@@ -866,7 +867,7 @@ class ItemEffects(wx.Panel):
         if 'wxMSW' in wx.PlatformInfo:
             os.startfile(file_)
         elif 'wxMac' in wx.PlatformInfo:
-            os.system("open " + file_)
+            os.system(u"open " + file_)
         else:
             subprocess.call(["xdg-open", file_])
 

--- a/gui/mainFrame.py
+++ b/gui/mainFrame.py
@@ -423,8 +423,8 @@ class MainFrame(wx.Frame):
             if format_ == 0:
                 sPort = Port.getInstance()
                 output = sPort.exportXml(None, fit)
-                if '.' not in os.path.basename(path):
-                    path += ".xml"
+                if u'.' not in os.path.basename(path):
+                    path += u".xml"
             else:
                 print("oops, invalid fit format %d" % format_)
                 try:
@@ -433,7 +433,7 @@ class MainFrame(wx.Frame):
                     pyfalog.error("Tried to destroy an object that doesn't exist in <showExportDialog>.")
                 return
 
-            with open(path, "w", encoding="utf-8") as openfile:
+            with open(path, "w") as openfile:
                 openfile.write(output)
                 openfile.close()
 
@@ -784,8 +784,8 @@ class MainFrame(wx.Frame):
                 saveFmt = "txt"
 
             filePath = saveDialog.GetPath()
-            if '.' not in os.path.basename(filePath):
-                filePath += ".{0}".format(saveFmt)
+            if u'.' not in os.path.basename(filePath):
+                filePath += u".{0}".format(saveFmt)
 
             self.waitDialog = wx.BusyInfo("Exporting skills needed...")
             sCharacter.backupSkills(filePath, saveFmt, self.getActiveFit(), self.closeWaitDialog)
@@ -832,8 +832,8 @@ class MainFrame(wx.Frame):
 
         if saveDialog.ShowModal() == wx.ID_OK:
             filePath = saveDialog.GetPath()
-            if '.' not in os.path.basename(filePath):
-                filePath += ".xml"
+            if u'.' not in os.path.basename(filePath):
+                filePath += u".xml"
 
             sFit = Fit.getInstance()
             max_ = sFit.countAllFits()

--- a/pyfa.py
+++ b/pyfa.py
@@ -222,11 +222,11 @@ if __name__ == "__main__":
     '''
 
     if options.debug:
-        savePath_filename = "Pyfa_debug.log"
+        savePath_filename = u"Pyfa_debug.log"
     else:
-        savePath_filename = "Pyfa.log"
+        savePath_filename = u"Pyfa.log"
 
-    config.logPath = os.path.join(config.savePath, savePath_filename)
+    config.logPath = config.getSavePath(savePath_filename)
 
     try:
         if options.debug:
@@ -359,7 +359,7 @@ if __name__ == "__main__":
             else:
                 pyfalog.warning("Unknown sqlalchemy version string format, skipping check. Version: {0}", sqlalchemy.__version__)
 
-        requirements_path = os.path.join(config.pyfaPath, "requirements.txt")
+        requirements_path = config.getPyfaPath(u"requirements.txt")
         if os.path.exists(requirements_path):
             file = open(requirements_path, "r")
             for requirement in file:

--- a/pyfa.py
+++ b/pyfa.py
@@ -28,7 +28,7 @@ from imp import find_module
 from optparse import AmbiguousOptionError, BadOptionError, OptionParser
 from multiprocessing import freeze_support
 
-# from service.serviceThreads import executeStartupThreads
+from service.serviceThreads import executeStartupThreads
 
 from logbook import CRITICAL, DEBUG, ERROR, FingersCrossedHandler, INFO, Logger, NestedSetup, NullHandler, StreamHandler, TimedRotatingFileHandler, WARNING, \
     __version__ as logbook_version
@@ -381,7 +381,7 @@ if __name__ == "__main__":
         eos.db.saveddata_meta.create_all()
 
         pyfalog.info("Starting threads")
-        # executeStartupThreads()
+        executeStartupThreads()
 
         from gui.mainFrame import MainFrame
 

--- a/pyfa.py
+++ b/pyfa.py
@@ -28,7 +28,7 @@ from imp import find_module
 from optparse import AmbiguousOptionError, BadOptionError, OptionParser
 from multiprocessing import freeze_support
 
-from service.serviceThreads import executeStartupThreads
+# from service.serviceThreads import executeStartupThreads
 
 from logbook import CRITICAL, DEBUG, ERROR, FingersCrossedHandler, INFO, Logger, NestedSetup, NullHandler, StreamHandler, TimedRotatingFileHandler, WARNING, \
     __version__ as logbook_version
@@ -284,9 +284,6 @@ if __name__ == "__main__":
     with logging_setup.threadbound():
         pyfalog.info("Starting Pyfa")
 
-        pyfalog.info("Starting threads")
-        # executeStartupThreads()
-
         pyfalog.info("Logbook version: {0}", logbook_version)
 
         pyfalog.info("Running in logging mode: {0}", logging_mode)
@@ -382,6 +379,9 @@ if __name__ == "__main__":
             os.mkdir(config.savePath)
 
         eos.db.saveddata_meta.create_all()
+
+        pyfalog.info("Starting threads")
+        # executeStartupThreads()
 
         from gui.mainFrame import MainFrame
 

--- a/pyfa.py
+++ b/pyfa.py
@@ -285,7 +285,7 @@ if __name__ == "__main__":
         pyfalog.info("Starting Pyfa")
 
         pyfalog.info("Starting threads")
-        executeStartupThreads()
+        # executeStartupThreads()
 
         pyfalog.info("Logbook version: {0}", logbook_version)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ urllib3
 requests == 2.11.1
 sqlalchemy >= 1.0.5
 EVE_Gnosis
+multiprocess >= 0.70.5

--- a/service/market.py
+++ b/service/market.py
@@ -21,6 +21,7 @@ import re
 import threading
 from logbook import Logger
 import Queue
+from time import time
 
 # noinspection PyPackageRequirements
 import wx
@@ -133,6 +134,11 @@ class SearchWorkerThread(threading.Thread):
 
     def scheduleSearch(self, text, callback, filterOn=True):
         self.cv.acquire()
+        self.searchRequestTime = time() + 5
+
+        while self.searchRequestTime < time():
+            self.cv.wait()
+
         self.searchRequest = (text, callback, filterOn)
         self.cv.notify()
         self.cv.release()

--- a/service/pycrest/eve.py
+++ b/service/pycrest/eve.py
@@ -43,7 +43,7 @@ class FileCache(APICache):
             os.mkdir(self.path, 0o700)
 
     def _getpath(self, key):
-        return os.path.join(self.path, str(hash(key)) + '.cache')
+        return os.path.join(self.path, str(hash(key)) + u'.cache')
 
     def put(self, key, value):
         with open(self._getpath(key), 'wb') as f:

--- a/service/serviceThreads.py
+++ b/service/serviceThreads.py
@@ -1,6 +1,5 @@
 import multiprocessing
-# from service.threads.eosEffectImports import threadedEosEffectsImport
-from service.threads.testThread import threadedEosEffectsImport
+from service.threads.eosEffectImports import threadedEosEffectsImport
 
 
 def executeStartupThreads():

--- a/service/serviceThreads.py
+++ b/service/serviceThreads.py
@@ -1,6 +1,7 @@
 import multiprocessing
-#from service.threads.eosEffectImports import threadedEosEffectsImport
+# from service.threads.eosEffectImports import threadedEosEffectsImport
 from service.threads.testThread import threadedEosEffectsImport
+
 
 def executeStartupThreads():
     """

--- a/service/serviceThreads.py
+++ b/service/serviceThreads.py
@@ -1,6 +1,6 @@
 import multiprocessing
-from service.threads.eosEffectImports import threadedEosEffectsImport
-
+#from service.threads.eosEffectImports import threadedEosEffectsImport
+from service.threads.testThread import threadedEosEffectsImport
 
 def executeStartupThreads():
     """

--- a/service/settings.py
+++ b/service/settings.py
@@ -22,15 +22,14 @@ import os.path
 import urllib2
 
 import config
-import eos.config
+import eos.config as eos_config
 from logbook import Logger
 
 pyfalog = Logger(__name__)
 
 
 class SettingsProvider(object):
-    if config.savePath:
-        BASE_PATH = os.path.join(config.savePath, 'settings')
+    BASE_PATH = config.getSavePath(u'settings')
     settings = {}
     _instance = None
 
@@ -263,7 +262,7 @@ class HTMLExportSettings(object):
 
     def __init__(self):
         serviceHTMLExportDefaultSettings = {
-            "path"   : config.pyfaPath + os.sep + 'pyfaFits.html',
+            "path"   : config.getPyfaPath(u'pyfaFits.html'),
             "minimal": False
         }
         self.serviceHTMLExportSettings = SettingsProvider.getInstance().getSettings(
@@ -476,7 +475,7 @@ class EOSSettings(object):
         return cls._instance
 
     def __init__(self):
-        self.EOSSettings = SettingsProvider.getInstance().getSettings("pyfaEOSSettings", eos.config.settings)
+        self.EOSSettings = SettingsProvider.getInstance().getSettings("pyfaEOSSettings", eos_config.settings)
 
     def get(self, type):
         return self.EOSSettings[type]

--- a/service/threads/testThread.py
+++ b/service/threads/testThread.py
@@ -1,0 +1,9 @@
+import os
+from importlib import import_module
+
+
+def threadedEosEffectsImport():
+    # Walk eos.effects and add all effects so we can import them properly
+    print("Starting Test Thread")
+
+    print("Completed Test Thread")

--- a/service/threads/testThread.py
+++ b/service/threads/testThread.py
@@ -1,5 +1,0 @@
-def threadedEosEffectsImport():
-    # Walk eos.effects and add all effects so we can import them properly
-    print("Starting Test Thread")
-
-    print("Completed Test Thread")

--- a/service/threads/testThread.py
+++ b/service/threads/testThread.py
@@ -1,7 +1,3 @@
-import os
-from importlib import import_module
-
-
 def threadedEosEffectsImport():
     # Walk eos.effects and add all effects so we can import them properly
     print("Starting Test Thread")

--- a/tests/test_locale/file_dialog.py
+++ b/tests/test_locale/file_dialog.py
@@ -6,7 +6,7 @@ import sys
 
 script_dir = os.path.dirname(os.path.abspath(__file__))
 # Add root to python paths, this allows us to import submodules
-sys.path.append(os.path.realpath(os.path.join(script_dir, '..', '..')))
+sys.path.append(os.path.realpath(os.path.join(script_dir, u'..', u'..')))
 
 from _development.helpers_locale import GetPath, GetUnicodePath
 

--- a/tests/test_locale/test_Pyfa/test_codec_english.py
+++ b/tests/test_locale/test_Pyfa/test_codec_english.py
@@ -6,7 +6,7 @@ import sys
 
 script_dir = os.path.dirname(os.path.abspath(__file__))
 # Add root to python paths, this allows us to import submodules
-sys.path.append(os.path.realpath(os.path.join(script_dir, '..', '..', '..')))
+sys.path.append(os.path.realpath(os.path.join(script_dir, u'..', u'..', u'..')))
 
 from _development.helpers_locale import GetPath
 

--- a/tests/test_locale/test_Pyfa/test_codec_english.py
+++ b/tests/test_locale/test_Pyfa/test_codec_english.py
@@ -4,9 +4,7 @@ import os
 import platform
 import sys
 
-script_dir = os.path.dirname(os.path.abspath(__file__))
-# Add root to python paths, this allows us to import submodules
-sys.path.append(os.path.realpath(os.path.join(script_dir, u'..', u'..', u'..')))
+sys.path.append(os.path.realpath(os.getcwd()))
 
 from _development.helpers_locale import GetPath
 

--- a/tests/test_locale/test_os_walk.py
+++ b/tests/test_locale/test_os_walk.py
@@ -1,9 +1,7 @@
 import os
 import sys
 
-script_dir = os.path.dirname(os.path.abspath(__file__))
-# Add root to python paths, this allows us to import submodules
-sys.path.append(os.path.realpath(os.path.join(script_dir, u'..', u'..')))
+sys.path.append(os.path.realpath(os.getcwd()))
 
 from _development.helpers_locale import GetPath
 

--- a/tests/test_locale/test_os_walk.py
+++ b/tests/test_locale/test_os_walk.py
@@ -3,7 +3,7 @@ import sys
 
 script_dir = os.path.dirname(os.path.abspath(__file__))
 # Add root to python paths, this allows us to import submodules
-sys.path.append(os.path.realpath(os.path.join(script_dir, '..', '..')))
+sys.path.append(os.path.realpath(os.path.join(script_dir, u'..', u'..')))
 
 from _development.helpers_locale import GetPath
 

--- a/tests/test_locale/test_знаф/test_codec_russian.py
+++ b/tests/test_locale/test_знаф/test_codec_russian.py
@@ -6,7 +6,7 @@ import sys
 
 script_dir = os.path.dirname(os.path.abspath(__file__))
 # Add root to python paths, this allows us to import submodules
-sys.path.append(os.path.realpath(os.path.join(script_dir, '..', '..', '..')))
+sys.path.append(os.path.realpath(os.path.join(script_dir, u'..', u'..', u'..')))
 
 from _development.helpers_locale import GetPath
 

--- a/tests/test_locale/test_знаф/test_codec_russian.py
+++ b/tests/test_locale/test_знаф/test_codec_russian.py
@@ -4,9 +4,7 @@ import os
 import platform
 import sys
 
-script_dir = os.path.dirname(os.path.abspath(__file__))
-# Add root to python paths, this allows us to import submodules
-sys.path.append(os.path.realpath(os.path.join(script_dir, u'..', u'..', u'..')))
+sys.path.append(os.path.realpath(os.getcwd()))
 
 from _development.helpers_locale import GetPath
 

--- a/tests/test_locale/test_פטכש/test_codec_hebrew.py
+++ b/tests/test_locale/test_פטכש/test_codec_hebrew.py
@@ -6,7 +6,7 @@ import sys
 
 script_dir = os.path.dirname(os.path.abspath(__file__))
 # Add root to python paths, this allows us to import submodules
-sys.path.append(os.path.realpath(os.path.join(script_dir, '..', '..', '..')))
+sys.path.append(os.path.realpath(os.path.join(script_dir, u'..', u'..', u'..')))
 
 from _development.helpers_locale import GetPath
 

--- a/tests/test_locale/test_פטכש/test_codec_hebrew.py
+++ b/tests/test_locale/test_פטכש/test_codec_hebrew.py
@@ -4,9 +4,7 @@ import os
 import platform
 import sys
 
-script_dir = os.path.dirname(os.path.abspath(__file__))
-# Add root to python paths, this allows us to import submodules
-sys.path.append(os.path.realpath(os.path.join(script_dir, u'..', u'..', u'..')))
+sys.path.append(os.path.realpath(os.getcwd()))
 
 from _development.helpers_locale import GetPath
 

--- a/tests/test_locale/test_测试/test_codec_chinese_simplified.py
+++ b/tests/test_locale/test_测试/test_codec_chinese_simplified.py
@@ -6,7 +6,7 @@ import sys
 
 script_dir = os.path.dirname(os.path.abspath(__file__))
 # Add root to python paths, this allows us to import submodules
-sys.path.append(os.path.realpath(os.path.join(script_dir, '..', '..', '..')))
+sys.path.append(os.path.realpath(os.path.join(script_dir, u'..', u'..', u'..')))
 
 from _development.helpers_locale import GetPath
 

--- a/tests/test_locale/test_测试/test_codec_chinese_simplified.py
+++ b/tests/test_locale/test_测试/test_codec_chinese_simplified.py
@@ -4,9 +4,7 @@ import os
 import platform
 import sys
 
-script_dir = os.path.dirname(os.path.abspath(__file__))
-# Add root to python paths, this allows us to import submodules
-sys.path.append(os.path.realpath(os.path.join(script_dir, u'..', u'..', u'..')))
+sys.path.append(os.path.realpath(os.getcwd()))
 
 from _development.helpers_locale import GetPath
 

--- a/tests/test_modules/test_eos/test_gamedata.py
+++ b/tests/test_modules/test_eos/test_gamedata.py
@@ -4,7 +4,7 @@ import os
 import sys
 
 script_dir = os.path.dirname(os.path.abspath(__file__))
-sys.path.append(os.path.realpath(os.path.join(script_dir, '..', '..', '..')))
+sys.path.append(os.path.realpath(os.path.join(script_dir, u'..', u'..', u'..')))
 
 # noinspection PyPackageRequirements
 from _development.helpers import DBInMemory as DB, Gamedata, Saveddata

--- a/tests/test_modules/test_eos/test_gamedata.py
+++ b/tests/test_modules/test_eos/test_gamedata.py
@@ -2,9 +2,9 @@
 # This must be done on every test in order to pass in Travis
 import os
 import sys
+import os
 
-script_dir = os.path.dirname(os.path.abspath(__file__))
-sys.path.append(os.path.realpath(os.path.join(script_dir, u'..', u'..', u'..')))
+sys.path.append(os.path.realpath(os.getcwd()))
 
 # noinspection PyPackageRequirements
 from _development.helpers import DBInMemory as DB, Gamedata, Saveddata

--- a/tests/test_modules/test_eos/test_modifiedAttributeDict.py
+++ b/tests/test_modules/test_eos/test_modifiedAttributeDict.py
@@ -5,7 +5,7 @@ import os
 import sys
 
 script_dir = os.path.dirname(os.path.abspath(__file__))
-script_dir = os.path.realpath(os.path.join(script_dir, '..', '..', '..'))
+script_dir = os.path.realpath(os.path.join(script_dir, u'..', u'..', u'..'))
 print script_dir
 sys.path.append(script_dir)
 

--- a/tests/test_modules/test_eos/test_modifiedAttributeDict.py
+++ b/tests/test_modules/test_eos/test_modifiedAttributeDict.py
@@ -4,10 +4,7 @@ import math
 import os
 import sys
 
-script_dir = os.path.dirname(os.path.abspath(__file__))
-script_dir = os.path.realpath(os.path.join(script_dir, u'..', u'..', u'..'))
-print script_dir
-sys.path.append(script_dir)
+sys.path.append(os.path.realpath(os.getcwd()))
 
 # noinspection PyPackageRequirements
 from _development.helpers import DBInMemory as DB, Gamedata, Saveddata

--- a/tests/test_modules/test_eos/test_saveddata/test_booster.py
+++ b/tests/test_modules/test_eos/test_saveddata/test_booster.py
@@ -3,8 +3,7 @@
 import os
 import sys
 
-script_dir = os.path.dirname(os.path.abspath(__file__))
-sys.path.append(os.path.realpath(os.path.join(script_dir, u'..', u'..', u'..', u'..')))
+sys.path.append(os.path.realpath(os.getcwd()))
 
 # noinspection PyPackageRequirements
 from _development.helpers import DBInMemory as DB, Gamedata, Saveddata

--- a/tests/test_modules/test_eos/test_saveddata/test_booster.py
+++ b/tests/test_modules/test_eos/test_saveddata/test_booster.py
@@ -4,7 +4,7 @@ import os
 import sys
 
 script_dir = os.path.dirname(os.path.abspath(__file__))
-sys.path.append(os.path.realpath(os.path.join(script_dir, '..', '..', '..', '..')))
+sys.path.append(os.path.realpath(os.path.join(script_dir, u'..', u'..', u'..', u'..')))
 
 # noinspection PyPackageRequirements
 from _development.helpers import DBInMemory as DB, Gamedata, Saveddata

--- a/tests/test_modules/test_eos/test_saveddata/test_fit_2.py
+++ b/tests/test_modules/test_eos/test_saveddata/test_fit_2.py
@@ -7,7 +7,7 @@ import sys
 from copy import deepcopy
 
 script_dir = os.path.dirname(os.path.abspath(__file__))
-sys.path.append(os.path.realpath(os.path.join(script_dir, '..', '..', '..', '..')))
+sys.path.append(os.path.realpath(os.path.join(script_dir, u'..', u'..', u'..', u'..')))
 
 # noinspection PyPackageRequirements
 from _development.helpers import DBInMemory as DB, Gamedata, Saveddata

--- a/tests/test_modules/test_eos/test_saveddata/test_fit_2.py
+++ b/tests/test_modules/test_eos/test_saveddata/test_fit_2.py
@@ -6,8 +6,7 @@ import os
 import sys
 from copy import deepcopy
 
-script_dir = os.path.dirname(os.path.abspath(__file__))
-sys.path.append(os.path.realpath(os.path.join(script_dir, u'..', u'..', u'..', u'..')))
+sys.path.append(os.path.realpath(os.getcwd()))
 
 # noinspection PyPackageRequirements
 from _development.helpers import DBInMemory as DB, Gamedata, Saveddata

--- a/tests/test_modules/test_gui/test_aboutData.py
+++ b/tests/test_modules/test_gui/test_aboutData.py
@@ -4,7 +4,7 @@ import os
 import sys
 
 script_dir = os.path.dirname(os.path.abspath(__file__))
-sys.path.append(os.path.realpath(os.path.join(script_dir, '..', '..', '..')))
+sys.path.append(os.path.realpath(os.path.join(script_dir, u'..', u'..', u'..')))
 
 from gui.aboutData import versionString, licenses, developers, credits, description
 

--- a/tests/test_modules/test_gui/test_aboutData.py
+++ b/tests/test_modules/test_gui/test_aboutData.py
@@ -3,8 +3,7 @@
 import os
 import sys
 
-script_dir = os.path.dirname(os.path.abspath(__file__))
-sys.path.append(os.path.realpath(os.path.join(script_dir, u'..', u'..', u'..')))
+sys.path.append(os.path.realpath(os.getcwd()))
 
 from gui.aboutData import versionString, licenses, developers, credits, description
 

--- a/tests/test_modules/test_service/test_attribute.py
+++ b/tests/test_modules/test_service/test_attribute.py
@@ -3,8 +3,7 @@
 import os
 import sys
 
-script_dir = os.path.dirname(os.path.abspath(__file__))
-sys.path.append(os.path.realpath(os.path.join(script_dir, u'..', u'..', u'..')))
+sys.path.append(os.path.realpath(os.getcwd()))
 
 from service.attribute import Attribute
 

--- a/tests/test_modules/test_service/test_attribute.py
+++ b/tests/test_modules/test_service/test_attribute.py
@@ -4,7 +4,7 @@ import os
 import sys
 
 script_dir = os.path.dirname(os.path.abspath(__file__))
-sys.path.append(os.path.realpath(os.path.join(script_dir, '..', '..', '..')))
+sys.path.append(os.path.realpath(os.path.join(script_dir, u'..', u'..', u'..')))
 
 from service.attribute import Attribute
 

--- a/tests/test_modules/test_service/test_fit.py
+++ b/tests/test_modules/test_service/test_fit.py
@@ -2,8 +2,7 @@
 import os
 import sys
 
-script_dir = os.path.dirname(os.path.abspath(__file__))
-sys.path.append(os.path.realpath(os.path.join(script_dir, u'..', u'..', u'..')))
+sys.path.append(os.path.realpath(os.getcwd()))
 
 # noinspection PyPackageRequirements
 from _development.helpers import DBInMemory as DB, Gamedata, Saveddata

--- a/tests/test_modules/test_service/test_fit.py
+++ b/tests/test_modules/test_service/test_fit.py
@@ -3,7 +3,7 @@ import os
 import sys
 
 script_dir = os.path.dirname(os.path.abspath(__file__))
-sys.path.append(os.path.realpath(os.path.join(script_dir, '..', '..', '..')))
+sys.path.append(os.path.realpath(os.path.join(script_dir, u'..', u'..', u'..')))
 
 # noinspection PyPackageRequirements
 from _development.helpers import DBInMemory as DB, Gamedata, Saveddata

--- a/tests/test_smoketests/test_rifter.py
+++ b/tests/test_smoketests/test_rifter.py
@@ -3,8 +3,7 @@
 import os
 import sys
 
-script_dir = os.path.dirname(os.path.abspath(__file__))
-sys.path.append(os.path.realpath(os.path.join(script_dir, u'..', u'..')))
+sys.path.append(os.path.realpath(os.getcwd()))
 
 # noinspection PyPackageRequirements
 from _development.helpers import DBInMemory as DB, Gamedata, Saveddata

--- a/tests/test_smoketests/test_rifter.py
+++ b/tests/test_smoketests/test_rifter.py
@@ -4,7 +4,7 @@ import os
 import sys
 
 script_dir = os.path.dirname(os.path.abspath(__file__))
-sys.path.append(os.path.realpath(os.path.join(script_dir, '..', '..')))
+sys.path.append(os.path.realpath(os.path.join(script_dir, u'..', u'..')))
 
 # noinspection PyPackageRequirements
 from _development.helpers import DBInMemory as DB, Gamedata, Saveddata


### PR DESCRIPTION
Enabling unicode handling across Pyfa.

Uses a single location to get the root and user directory.  We do this because it's easier to handle all the gotchas with unicode and Python 2.7 in a single location.

There's a bug in Python 2.x for `expanduser` when running in Windows, and there are unicode characters in the path.  We have to roll our own to work around it.
See:
http://bugs.python.org/issue13207
http://stackoverflow.com/questions/23888120/an-alternative-to-os-path-expanduser

Some general cleanup and better handling of paths.