### PR TITLE
Gnosis: Add Capacitor Booster Fire when Percentage is Reached

### DIFF
--- a/eos/config.py
+++ b/eos/config.py
@@ -29,6 +29,7 @@ pyfalog.debug("Saveddata connection string: {0}", saveddata_connectionstring)
 settings = {
     "useStaticAdaptiveArmorHardener": False,
     "strictFitting"                 : True,
+    "fireAtPercentCapacitor"        : 25,
 }
 
 # Autodetect path, only change if the autodetection bugs out.

--- a/eos/gnosis.py
+++ b/eos/gnosis.py
@@ -4,6 +4,7 @@ Integrates Gnosis into Pyfa
 
 from EVE_Gnosis.formulas.formulas import Formulas
 from EVE_Gnosis.simulations.capacitor import Capacitor
+from eos.config import settings
 
 
 class GnosisFormulas(object):
@@ -86,6 +87,12 @@ class GnosisSimulation(object):
                 if capacitor_need < 0 and not reactivation_delay and add_reactivation_delay:
                     reactivation_delay = add_reactivation_delay
 
+                # If we have charges and a positive influence at the capacitor, only fire it off when we get low enough.
+                if charges and capacitor_need > 0:
+                    fire_at_percent = float(settings['fireAtPercentCapacitor']) / 100
+                else:
+                    fire_at_percent = False
+
                 if (capacitor_need and duration) is not None:
                     module_list.append(
                             {
@@ -97,6 +104,7 @@ class GnosisSimulation(object):
                                 'ShieldRepair'     : shield_reps,
                                 'ArmorRepair'      : armor_reps,
                                 'HullRepair'       : hull_reps,
+                                'FireAtPercent'    : fire_at_percent,
                             }
                     )
 

--- a/gui/builtinPreferenceViews/pyfaEnginePreferences.py
+++ b/gui/builtinPreferenceViews/pyfaEnginePreferences.py
@@ -1,6 +1,7 @@
 import logging
 
 import wx
+from wx.lib.intctrl import IntCtrl
 
 from service.fit import Fit
 from gui.bitmapLoader import BitmapLoader
@@ -47,6 +48,20 @@ class PFFittingEnginePref(PreferenceView):
                                            wx.DefaultPosition, wx.DefaultSize, 0)
         mainSizer.Add(self.cbStrictFitting, 0, wx.ALL | wx.EXPAND, 5)
 
+        # Search Item Limit
+        sizerFireAtPercentCapacitor = wx.BoxSizer(wx.HORIZONTAL)
+
+        self.cbFireAtPercentCapacitorText = wx.StaticText(panel, wx.ID_ANY,
+                                                          u"Use capacitor boosters when this percentage is reached: ",
+                                                          wx.DefaultPosition, wx.DefaultSize, 0
+                                                         )
+        self.cbFireAtPercentCapacitorText.Wrap(-1)
+        sizerFireAtPercentCapacitor.Add(self.cbFireAtPercentCapacitorText, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
+        self.editFireAtPercentCapacitor = IntCtrl(panel, max=99, limited=True)
+        sizerFireAtPercentCapacitor.Add(self.editFireAtPercentCapacitor, 0, wx.ALL, 5)
+
+        mainSizer.Add(sizerFireAtPercentCapacitor, 0, wx.ALL | wx.EXPAND, 0)
+
         # Future code once new cap sim is implemented
         '''
         self.cbGlobalForceReactivationTimer = wx.CheckBox( panel, wx.ID_ANY, u"Factor in reactivation timer", wx.DefaultPosition, wx.DefaultSize, 0 )
@@ -82,6 +97,9 @@ class PFFittingEnginePref(PreferenceView):
         self.cbStrictFitting.SetValue(self.engine_settings.get("strictFitting"))
         self.cbStrictFitting.Bind(wx.EVT_CHECKBOX, self.OnCBStrictFittingChange)
 
+        self.editFireAtPercentCapacitor.SetValue(int(self.engine_settings.get("fireAtPercentCapacitor")))
+        self.editFireAtPercentCapacitor.Bind(wx.lib.intctrl.EVT_INT, self.OnWindowLeave)
+
         panel.SetSizer(mainSizer)
         panel.Layout()
 
@@ -98,9 +116,7 @@ class PFFittingEnginePref(PreferenceView):
         return BitmapLoader.getBitmap("settings_fitting", "gui")
 
     def OnWindowLeave(self, event):
-        # We don't want to do anything when they leave,
-        # but in the future we might.
-        pass
+        self.engine_settings.set('fireAtPercentCapacitor', int(self.editFireAtPercentCapacitor.GetValue()))
 
 
 PFFittingEnginePref.register()

--- a/gui/builtinPreferenceViews/pyfaEnginePreferences.py
+++ b/gui/builtinPreferenceViews/pyfaEnginePreferences.py
@@ -51,11 +51,12 @@ class PFFittingEnginePref(PreferenceView):
         # Search Item Limit
         sizerFireAtPercentCapacitor = wx.BoxSizer(wx.HORIZONTAL)
 
-        self.cbFireAtPercentCapacitorText = wx.StaticText(panel, wx.ID_ANY,
-                                                          u"Use capacitor boosters when this percentage is reached: ",
-                                                          wx.DefaultPosition, wx.DefaultSize, 0
-                                                         )
         self.cbFireAtPercentCapacitorText.Wrap(-1)
+        self.cbFireAtPercentCapacitorText = wx.StaticText(
+                panel, wx.ID_ANY,
+                u"Use capacitor boosters when this percentage is reached: ",
+                wx.DefaultPosition, wx.DefaultSize, 0
+        )
         sizerFireAtPercentCapacitor.Add(self.cbFireAtPercentCapacitorText, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
         self.editFireAtPercentCapacitor = IntCtrl(panel, max=99, limited=True)
         sizerFireAtPercentCapacitor.Add(self.editFireAtPercentCapacitor, 0, wx.ALL, 5)

--- a/gui/builtinPreferenceViews/pyfaGeneralPreferences.py
+++ b/gui/builtinPreferenceViews/pyfaGeneralPreferences.py
@@ -118,8 +118,6 @@ class PFGeneralPref(PreferenceView):
         searchLimitSizer.Add(self.chSearchLimitText, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
         self.editSearchLimit = IntCtrl(panel, max=500, limited=True)
         searchLimitSizer.Add(self.editSearchLimit, 0, wx.ALL, 5)
-        # self.editSearchLimit = wx.TextCtrl(panel, wx.ID_ANY, "", wx.DefaultPosition, wx.DefaultSize, 0)
-        # searchLimitSizer.Add(self.editSearchLimit, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL | wx.EXPAND, 5)
 
         mainSizer.Add(searchLimitSizer, 0, wx.ALL | wx.EXPAND, 0)
 


### PR DESCRIPTION
Currently we blindly and madly fire off all the things every opportunity we get.  Especially for capacitor boosters, this is wasteful.  

First, we peak at around 25% (+-3-4% depending on the fit), so by firing at 80% instead of 20% we're wasting a lot of ticks that we could get much higher regen numbers.  

Secondly, we waste a bunch of charge power, especially with large charges.

So let's add a feature for that!
https://puu.sh/vi2zL/72f1aa5724.png

Here's how a Golem with a cap booster looks currently:
https://puu.sh/vi1wn/7425a90751.png

And here's how it looks with a fire at percentage of 25%:
https://puu.sh/vi2ws/d88672bcb6.png

You'll notice that our stability goes _down_.  That's because we're waiting until we hit 25% before firing our cap booster off.

This will be much more accurate to how players use cap boosters, and greatly improve capsim accuracy.