### PR TITLE
RELEASE: 2017.04.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,28 +11,33 @@ _Development_: [![Build Status](https://travis-ci.org/Pyfa-fit/Pyfa.svg?branch=d
 pyfa, short for **py**thon **f**itting **a**ssistant, allows you to create, experiment with, and save ship fittings without being in game. Open source and written in Python, it is available on any platform where Python 2.x and wxWidgets are available, including Windows, Mac OS X, and Linux.
 
 ## Latest Version and Changelogs
-### Windows
+
+The latest version along with release notes can always be found on the project's [Releases](https://github.com/Pyfa-fit/Pyfa/releases) page. pyfa will notify you if you are running an outdated version.  
+
+Development releases will have newer features, and may not function correctly. Use at your own risk.
 
 _*Release Downloads*_:
 [Current Release](https://github.com/Pyfa-fit/Pyfa/releases)
+
+### Windows
 
 _*Development Downloads*_:
 [x86](https://ci.appveyor.com/api/projects/Ebag333/pyfa-nr5qw/artifacts/pyfa.zip?branch=development&job=Environment%3A%20PYTHON%3DC%3A%5CPython27%2C%20PYTHON_VERSION%3D2.7.x%2C%20PYTHON_ARCH%3D32)
  | 
 [x64](https://ci.appveyor.com/api/projects/Ebag333/pyfa-nr5qw/artifacts/pyfa.zip?branch=development&job=Environment%3A%20PYTHON%3DC%3A%5CPython27-x64%2C%20PYTHON_VERSION%3D2.7.x%2C%20PYTHON_ARCH%3D64)
 
-The latest version along with release notes can always be found on the project's [Releases](https://github.com/Pyfa-fit/Pyfa/releases) page. pyfa will notify you if you are running an outdated version.  
+### Linux/OS X
 
-Development releases will have newer features, and may not function correctly. Use at your own risk.
+_*Development Downloads*_:
+Can be fetched by download the current repository
 
 ## Installation
-Windows users are supplied self-contained builds of pyfa on the [latest releases](https://github.com/Pyfa-fit/Pyfa/releases/latest) page. An `.exe` installer is also available for Windows builds. Linux and Mac users can run pyfa using their distribution's Python interpreter. There is no official self-contained package for Linux or Mac (a feature currently in progress).
 
-#### OS X
-There are currently no OS X builds.  You can run by through emulation, or by running pyfa.py directly.
+### Windows
+Windows users are supplied self-contained builds of pyfa on the [latest releases](https://github.com/Pyfa-fit/Pyfa/releases/latest) page. An `.exe` installer is also available for Windows builds.
 
-### Linux Distro-specific Packages
-There are currently no Linux builds.  You can run by through emulation, or by running pyfa.py directly.
+#### Linux/OS X
+ Linux and Mac users can run pyfa using their distribution's Python interpreter. There is no official self-contained package for Linux or Mac (a feature currently in progress).
 
 ### Dependencies
 If you wish to help with development or simply need to run pyfa through a Python interpreter, all requirements are listed in `requirements.txt`.

--- a/config.py
+++ b/config.py
@@ -25,7 +25,7 @@ debug = False
 saveInRoot = False
 
 # Version data
-version = "2017.04.11"
+version = "2017.04.13"
 if hasattr(sys, 'frozen'):
     tag = "(release)"
 else:

--- a/config.py
+++ b/config.py
@@ -105,6 +105,10 @@ def defPaths(customSavePath):
     eos.config.saveddata_connectionstring = "sqlite:///" + saveDB + "?check_same_thread=False"
     eos.config.gamedata_connectionstring = "sqlite:///" + gameDB + "?check_same_thread=False"
 
+    # initialize the settings
+    from service.settings import EOSSettings
+    eos.config.settings = EOSSettings.getInstance().EOSSettings  # this is kind of confusing, but whatever
+
 
 def getPyfaPath(Append=None):
     base = __file__

--- a/eos/config.py
+++ b/eos/config.py
@@ -29,6 +29,7 @@ pyfalog.debug("Saveddata connection string: {0}", saveddata_connectionstring)
 settings = {
     "useStaticAdaptiveArmorHardener": False,
     "strictFitting"                 : True,
+    "fireAtPercentCapacitor"        : 25,
 }
 
 # Autodetect path, only change if the autodetection bugs out.

--- a/eos/db/saveddata/queries.py
+++ b/eos/db/saveddata/queries.py
@@ -521,6 +521,8 @@ def save(stuff):
 def remove(stuff):
     removeCachedEntry(type(stuff), stuff.ID)
     with sd_lock:
+        # Merge the object to make sure we don't already have it in session
+        saveddata_session.merge(stuff)
         saveddata_session.delete(stuff)
     commit()
 

--- a/eos/gamedata.py
+++ b/eos/gamedata.py
@@ -443,11 +443,6 @@ class Item(EqBase):
     @property
     def price(self):
         try:
-            # todo: use `from sqlalchemy import inspect` instead (need to verify it works in old and new OS X builds)
-            if self.__price is not None and getattr(self.__price, '_sa_instance_state', None):
-                pyfalog.debug("Price data for {} was deleted, resetting object".format(self.ID))
-                self.__price = None
-
             if self.__price is None:
                 db_price = eos.db.getPrice(self.ID)
                 # do not yet have a price in the database for this item, create one

--- a/eos/gnosis.py
+++ b/eos/gnosis.py
@@ -4,6 +4,7 @@ Integrates Gnosis into Pyfa
 
 from EVE_Gnosis.formulas.formulas import Formulas
 from EVE_Gnosis.simulations.capacitor import Capacitor
+from eos.config import settings
 
 
 class GnosisFormulas(object):
@@ -86,6 +87,12 @@ class GnosisSimulation(object):
                 if capacitor_need < 0 and not reactivation_delay and add_reactivation_delay:
                     reactivation_delay = add_reactivation_delay
 
+                # If we have charges and a positive influence at the capacitor, only fire it off when we get low enough.
+                if charges and capacitor_need > 0:
+                    fire_at_percent = float(settings['fireAtPercentCapacitor']) / 100
+                else:
+                    fire_at_percent = False
+
                 if (capacitor_need and duration) is not None:
                     module_list.append(
                             {
@@ -97,6 +104,7 @@ class GnosisSimulation(object):
                                 'ShieldRepair'     : shield_reps,
                                 'ArmorRepair'      : armor_reps,
                                 'HullRepair'       : hull_reps,
+                                'FireAtPercent'    : fire_at_percent,
                             }
                     )
 

--- a/eos/saveddata/fit.py
+++ b/eos/saveddata/fit.py
@@ -651,37 +651,6 @@ class Fit(object):
 
             del self.commandBonuses[warfareBuffID]
 
-    def validateFitChainCalculated(self):
-        """
-        Walks up the chain for the fit and anything projected or command fits haven't been calculated
-
-        :return:
-        True if all fits are calculated, False if one (or more) is not
-        """
-
-        for projected_fit in self.projectedFits:
-            if projected_fit.getProjectionInfo(self.ID).active:
-                if projected_fit is not self:
-                    if projected_fit.calculated is False:
-                        return False
-
-                    projected_calculated = projected_fit.validateFitChainCalculated()
-                    if projected_calculated is False:
-                        return False
-
-        for command_fit in self.commandFits:
-            if command_fit.getCommandInfo(self.ID).active:
-                if command_fit is not self:
-                    if command_fit.calculated is False:
-                        return False
-
-                    command_calculated = command_fit.validateFitChainCalculated()
-                    if command_calculated is False:
-                        return False
-
-        # print("For (" + str(self.name) + ") returning chain have been calculated")
-        return True
-
     def clearFitChainCalculated(self):
         """
         Walks up the chain for the fit and clear the calculated flag on any projected or command fits
@@ -689,19 +658,25 @@ class Fit(object):
         :return:
         True if all fits are calculated, False if one (or more) is not
         """
-        # print("Clearing calculated flag on: " + str(self.name))
 
         for projected_fit in self.projectedFits:
             if projected_fit.getProjectionInfo(self.ID).active:
-                if projected_fit is not self:
-                    projected_fit.clearFitChainCalculated()
+                if projected_fit is not self and projected_fit.calculated is True:
+                    projected_fit.calculated = False
+                    pyfalog.debug("Clearing fit calculation flag on: {0}", projected_fit.ID)
+
+                for projected_command_fit in projected_fit.commandFits:
+                    if projected_command_fit is not self and projected_command_fit.calculated is True:
+                        projected_command_fit.calculated = False
+                        pyfalog.debug("Clearing fit calculation flag on: {0}", projected_command_fit.ID)
 
         for command_fit in self.commandFits:
-            if command_fit.getCommandInfo(self.ID).active:
-                if command_fit is not self:
-                    command_fit.clearFitChainCalculated()
+            if command_fit is not self and command_fit.calculated is True:
+                command_fit.calculated = False
+                pyfalog.debug("Clearing fit calculation flag on: {0}", command_fit.ID)
 
         self.calculated = False
+        pyfalog.debug("Clearing fit calculation flag on: {0}", self.ID)
 
     def calculateFitAttributes(self, targetFit=None, withBoosters=False):
         """
@@ -728,8 +703,7 @@ class Fit(object):
         pyfalog.debug("Starting fit calculation.")
 
         # Follow the chain, if we find any fits not calculated, recalc them all.
-        if not self.validateFitChainCalculated():
-            self.clearFitChainCalculated()
+        self.clearFitChainCalculated()
 
         if withBoosters:
             # Recalc ships projecting onto this fit
@@ -739,20 +713,27 @@ class Fit(object):
                         # If fit is self, don't recurse
                         self.calculateModifiedFitAttributes(targetFit=self)
                     else:
-                        projected_fit.calculateFitAttributes(withBoosters=withBoosters, targetFit=self)
+                        for projected_command_fit in projected_fit.commandFits:
+                            projected_onto = projected_command_fit.getCommandInfo(self.ID)
+                            if getattr(projected_onto, 'active', None):
+                                if projected_command_fit is not self:
+                                    projected_command_fit.calculateModifiedFitAttributes()
+                                    projected_command_fit.calculateModifiedFitAttributes(targetFit=projected_fit)
+
+                        projected_fit.calculateModifiedFitAttributes()
+                        projected_fit.calculateModifiedFitAttributes(targetFit=self)
 
             for command_fit in self.commandFits:
-                if command_fit.getCommandInfo(self.ID).active:
+                projected_onto = command_fit.getCommandInfo(self.ID)
+                if getattr(projected_onto, 'active', None):
                     if command_fit is self:
                         # If fit is self, don't recurse
                         self.calculateModifiedFitAttributes(targetFit=self)
                     else:
-                        command_fit.calculateFitAttributes(withBoosters=withBoosters, targetFit=self)
+                        command_fit.calculateModifiedFitAttributes()
+                        command_fit.calculateModifiedFitAttributes(targetFit=self)
 
         self.calculateModifiedFitAttributes()
-
-        if targetFit:
-            self.calculateModifiedFitAttributes(targetFit=targetFit)
 
     def calculateModifiedFitAttributes(self, targetFit=None):
         """
@@ -762,12 +743,11 @@ class Fit(object):
         If a target fit is specified, will project onto the target fit.
         If targetFit is the same as self, then we make a copy in order to properly project it without running into recursion issues.
         """
-        pyfalog.debug("Starting fit calculation on: {0}", self.name)
 
         shadow = None
         projectionInfo = None
         if targetFit:
-            pyfalog.debug("Calculating projections from {0} to target {1}", self.name, targetFit.name)
+            pyfalog.info("Calculating projections from {0} to target {1}", self.name, targetFit.name)
             projectionInfo = self.getProjectionInfo(targetFit.ID)
             pyfalog.debug("ProjectionInfo: {0}", projectionInfo)
             if self is targetFit:
@@ -777,6 +757,8 @@ class Fit(object):
                 # noinspection PyMethodFirstArgAssignment
                 self = shadow
                 pyfalog.debug("Handling self projection - making shadow copy of fit.")
+        else:
+            pyfalog.info("Calculating fit {0}", self.name)
 
         # If fit is calculated and we have nothing to do here, get out
 
@@ -870,10 +852,8 @@ class Fit(object):
             except InvalidRequestError:
                 # Older versions of SQLAlchemy are not forgiving of the delete command. Newer versions seem to use it more as a delete or expunge.
                 # Test a pass here to see if we can just skip it, may need a refresh or other cleanup.
-                print("Caught InvalidRequestError when  deleting the shadow fit out of the database.")
+                pyfalog.warning("Caught InvalidRequestError when deleting the shadow fit out of the database.")
             del shadow
-
-        pyfalog.debug('Done with fit calculation')
 
         pyfalog.debug('Done with fit calculation')
 

--- a/eos/saveddata/fit.py
+++ b/eos/saveddata/fit.py
@@ -675,9 +675,6 @@ class Fit(object):
                 command_fit.calculated = False
                 pyfalog.debug("Clearing fit calculation flag on: {0}", command_fit.ID)
 
-        self.calculated = False
-        pyfalog.debug("Clearing fit calculation flag on: {0}", self.ID)
-
     def calculateFitAttributes(self, targetFit=None, withBoosters=False):
         """
         This method handles recursion through the chain of fit, projected fits, and command fits.  We start from our current fit (self), then recurse up through

--- a/gui/builtinPreferenceViews/pyfaEnginePreferences.py
+++ b/gui/builtinPreferenceViews/pyfaEnginePreferences.py
@@ -1,6 +1,7 @@
 import logging
 
 import wx
+from wx.lib.intctrl import IntCtrl
 
 from service.fit import Fit
 from gui.bitmapLoader import BitmapLoader
@@ -47,6 +48,20 @@ class PFFittingEnginePref(PreferenceView):
                                            wx.DefaultPosition, wx.DefaultSize, 0)
         mainSizer.Add(self.cbStrictFitting, 0, wx.ALL | wx.EXPAND, 5)
 
+        # Search Item Limit
+        sizerFireAtPercentCapacitor = wx.BoxSizer(wx.HORIZONTAL)
+
+        self.cbFireAtPercentCapacitorText = wx.StaticText(panel, wx.ID_ANY,
+                                                          u"Use capacitor boosters when this percentage is reached: ",
+                                                          wx.DefaultPosition, wx.DefaultSize, 0
+                                                         )
+        self.cbFireAtPercentCapacitorText.Wrap(-1)
+        sizerFireAtPercentCapacitor.Add(self.cbFireAtPercentCapacitorText, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
+        self.editFireAtPercentCapacitor = IntCtrl(panel, max=99, limited=True)
+        sizerFireAtPercentCapacitor.Add(self.editFireAtPercentCapacitor, 0, wx.ALL, 5)
+
+        mainSizer.Add(sizerFireAtPercentCapacitor, 0, wx.ALL | wx.EXPAND, 0)
+
         # Future code once new cap sim is implemented
         '''
         self.cbGlobalForceReactivationTimer = wx.CheckBox( panel, wx.ID_ANY, u"Factor in reactivation timer", wx.DefaultPosition, wx.DefaultSize, 0 )
@@ -82,6 +97,9 @@ class PFFittingEnginePref(PreferenceView):
         self.cbStrictFitting.SetValue(self.engine_settings.get("strictFitting"))
         self.cbStrictFitting.Bind(wx.EVT_CHECKBOX, self.OnCBStrictFittingChange)
 
+        self.editFireAtPercentCapacitor.SetValue(int(self.engine_settings.get("fireAtPercentCapacitor")))
+        self.editFireAtPercentCapacitor.Bind(wx.lib.intctrl.EVT_INT, self.OnWindowLeave)
+
         panel.SetSizer(mainSizer)
         panel.Layout()
 
@@ -98,9 +116,7 @@ class PFFittingEnginePref(PreferenceView):
         return BitmapLoader.getBitmap("settings_fitting", "gui")
 
     def OnWindowLeave(self, event):
-        # We don't want to do anything when they leave,
-        # but in the future we might.
-        pass
+        self.engine_settings.set('fireAtPercentCapacitor', int(self.editFireAtPercentCapacitor.GetValue()))
 
 
 PFFittingEnginePref.register()

--- a/gui/builtinPreferenceViews/pyfaEnginePreferences.py
+++ b/gui/builtinPreferenceViews/pyfaEnginePreferences.py
@@ -51,13 +51,13 @@ class PFFittingEnginePref(PreferenceView):
         # Search Item Limit
         sizerFireAtPercentCapacitor = wx.BoxSizer(wx.HORIZONTAL)
 
-        self.cbFireAtPercentCapacitorText.Wrap(-1)
-        self.cbFireAtPercentCapacitorText = wx.StaticText(
+        self.sizerFireAtPercentCapacitor.Wrap(-1)
+        self.sizerFireAtPercentCapacitor = wx.StaticText(
                 panel, wx.ID_ANY,
                 u"Use capacitor boosters when this percentage is reached: ",
                 wx.DefaultPosition, wx.DefaultSize, 0
         )
-        sizerFireAtPercentCapacitor.Add(self.cbFireAtPercentCapacitorText, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
+        sizerFireAtPercentCapacitor.Add(self.sizerFireAtPercentCapacitor, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
         self.editFireAtPercentCapacitor = IntCtrl(panel, max=99, limited=True)
         sizerFireAtPercentCapacitor.Add(self.editFireAtPercentCapacitor, 0, wx.ALL, 5)
 

--- a/gui/builtinPreferenceViews/pyfaEnginePreferences.py
+++ b/gui/builtinPreferenceViews/pyfaEnginePreferences.py
@@ -51,11 +51,12 @@ class PFFittingEnginePref(PreferenceView):
         # Search Item Limit
         sizerFireAtPercentCapacitor = wx.BoxSizer(wx.HORIZONTAL)
 
-        self.cbFireAtPercentCapacitorText = wx.StaticText(panel, wx.ID_ANY,
-                                                          u"Use capacitor boosters when this percentage is reached: ",
-                                                          wx.DefaultPosition, wx.DefaultSize, 0
-                                                         )
         self.cbFireAtPercentCapacitorText.Wrap(-1)
+        self.cbFireAtPercentCapacitorText = wx.StaticText(
+                panel, wx.ID_ANY,
+                u"Use capacitor boosters when this percentage is reached: ",
+                wx.DefaultPosition, wx.DefaultSize, 0
+        )
         sizerFireAtPercentCapacitor.Add(self.cbFireAtPercentCapacitorText, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
         self.editFireAtPercentCapacitor = IntCtrl(panel, max=99, limited=True)
         sizerFireAtPercentCapacitor.Add(self.editFireAtPercentCapacitor, 0, wx.ALL, 5)

--- a/gui/builtinPreferenceViews/pyfaEnginePreferences.py
+++ b/gui/builtinPreferenceViews/pyfaEnginePreferences.py
@@ -51,15 +51,15 @@ class PFFittingEnginePref(PreferenceView):
         # Search Item Limit
         sizerFireAtPercentCapacitor = wx.BoxSizer(wx.HORIZONTAL)
 
-        self.sizerFireAtPercentCapacitor.Wrap(-1)
-        self.sizerFireAtPercentCapacitor = wx.StaticText(
+        FireAtPercentCapacitorText = wx.StaticText(
                 panel, wx.ID_ANY,
                 u"Use capacitor boosters when this percentage is reached: ",
                 wx.DefaultPosition, wx.DefaultSize, 0
         )
-        sizerFireAtPercentCapacitor.Add(self.sizerFireAtPercentCapacitor, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
-        self.editFireAtPercentCapacitor = IntCtrl(panel, max=99, limited=True)
-        sizerFireAtPercentCapacitor.Add(self.editFireAtPercentCapacitor, 0, wx.ALL, 5)
+        FireAtPercentCapacitorText.Wrap(-1)
+        sizerFireAtPercentCapacitor.Add(FireAtPercentCapacitorText, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
+        editFireAtPercentCapacitor = IntCtrl(panel, max=99, limited=True)
+        sizerFireAtPercentCapacitor.Add(editFireAtPercentCapacitor, 0, wx.ALL, 5)
 
         mainSizer.Add(sizerFireAtPercentCapacitor, 0, wx.ALL | wx.EXPAND, 0)
 
@@ -98,8 +98,8 @@ class PFFittingEnginePref(PreferenceView):
         self.cbStrictFitting.SetValue(self.engine_settings.get("strictFitting"))
         self.cbStrictFitting.Bind(wx.EVT_CHECKBOX, self.OnCBStrictFittingChange)
 
-        self.editFireAtPercentCapacitor.SetValue(int(self.engine_settings.get("fireAtPercentCapacitor")))
-        self.editFireAtPercentCapacitor.Bind(wx.lib.intctrl.EVT_INT, self.OnWindowLeave)
+        editFireAtPercentCapacitor.SetValue(int(self.engine_settings.get("fireAtPercentCapacitor")))
+        editFireAtPercentCapacitor.Bind(wx.lib.intctrl.EVT_INT, self.OnWindowLeave)
 
         panel.SetSizer(mainSizer)
         panel.Layout()

--- a/gui/builtinPreferenceViews/pyfaGeneralPreferences.py
+++ b/gui/builtinPreferenceViews/pyfaGeneralPreferences.py
@@ -118,8 +118,6 @@ class PFGeneralPref(PreferenceView):
         searchLimitSizer.Add(self.chSearchLimitText, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
         self.editSearchLimit = IntCtrl(panel, max=500, limited=True)
         searchLimitSizer.Add(self.editSearchLimit, 0, wx.ALL, 5)
-        # self.editSearchLimit = wx.TextCtrl(panel, wx.ID_ANY, "", wx.DefaultPosition, wx.DefaultSize, 0)
-        # searchLimitSizer.Add(self.editSearchLimit, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL | wx.EXPAND, 5)
 
         mainSizer.Add(searchLimitSizer, 0, wx.ALL | wx.EXPAND, 0)
 

--- a/gui/builtinPreferenceViews/pyfaGeneralPreferences.py
+++ b/gui/builtinPreferenceViews/pyfaGeneralPreferences.py
@@ -110,7 +110,6 @@ class PFGeneralPref(PreferenceView):
 
         mainSizer.Add(delayTimer, 0, wx.ALL | wx.EXPAND, 0)
 
-
         # Search Item Limit
         searchLimitSizer = wx.BoxSizer(wx.HORIZONTAL)
 

--- a/gui/builtinPreferenceViews/pyfaGeneralPreferences.py
+++ b/gui/builtinPreferenceViews/pyfaGeneralPreferences.py
@@ -1,5 +1,6 @@
 # noinspection PyPackageRequirements
 import wx
+from wx.lib.intctrl import IntCtrl
 
 from gui.preferenceView import PreferenceView
 from gui.bitmapLoader import BitmapLoader
@@ -95,14 +96,31 @@ class PFGeneralPref(PreferenceView):
 
         mainSizer.Add(priceSizer, 0, wx.ALL | wx.EXPAND, 0)
 
+        delayTimer = wx.BoxSizer(wx.HORIZONTAL)
+
+        self.stMarketDelay = wx.StaticText(panel, wx.ID_ANY, u"Market Search Delay (ms):", wx.DefaultPosition, wx.DefaultSize, 0)
+        self.stMarketDelay.Wrap(-1)
+        self.stMarketDelay.SetToolTip(
+            wx.ToolTip('The delay between a keystroke and the market search. Can help reduce lag when typing fast in the market search box.'))
+
+        delayTimer.Add(self.stMarketDelay, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
+
+        self.intDelay = IntCtrl(panel, max=1000, limited=True)
+        delayTimer.Add(self.intDelay, 0, wx.ALL, 5)
+
+        mainSizer.Add(delayTimer, 0, wx.ALL | wx.EXPAND, 0)
+
+
         # Search Item Limit
         searchLimitSizer = wx.BoxSizer(wx.HORIZONTAL)
 
         self.chSearchLimitText = wx.StaticText(panel, wx.ID_ANY, u"Item Search Limit:", wx.DefaultPosition, wx.DefaultSize, 0)
         self.chSearchLimitText.Wrap(-1)
         searchLimitSizer.Add(self.chSearchLimitText, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
-        self.editSearchLimit = wx.TextCtrl(panel, wx.ID_ANY, "", wx.DefaultPosition, wx.DefaultSize, 0)
-        searchLimitSizer.Add(self.editSearchLimit, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL | wx.EXPAND, 5)
+        self.editSearchLimit = IntCtrl(panel, max=500, limited=True)
+        searchLimitSizer.Add(self.editSearchLimit, 0, wx.ALL, 5)
+        # self.editSearchLimit = wx.TextCtrl(panel, wx.ID_ANY, "", wx.DefaultPosition, wx.DefaultSize, 0)
+        # searchLimitSizer.Add(self.editSearchLimit, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL | wx.EXPAND, 5)
 
         mainSizer.Add(searchLimitSizer, 0, wx.ALL | wx.EXPAND, 0)
 
@@ -120,7 +138,8 @@ class PFGeneralPref(PreferenceView):
         self.cbOpenFitInNew.SetValue(self.sFit.serviceFittingOptions["openFitInNew"])
         self.chPriceSystem.SetStringSelection(self.sFit.serviceFittingOptions["priceSystem"])
         self.cbShowShipBrowserTooltip.SetValue(self.sFit.serviceFittingOptions["showShipBrowserTooltip"])
-        self.editSearchLimit.SetValue(unicode(self.generalSettings.get("itemSearchLimit")))
+        self.intDelay.SetValue(self.generalSettings.get("marketSearchDelay"))
+        self.editSearchLimit.SetValue(int(self.generalSettings.get("itemSearchLimit")))
 
         self.cbGlobalChar.Bind(wx.EVT_CHECKBOX, self.OnWindowLeave)
         self.cbGlobalDmgPattern.Bind(wx.EVT_CHECKBOX, self.OnWindowLeave)
@@ -137,6 +156,8 @@ class PFGeneralPref(PreferenceView):
         self.chPriceSystem.Bind(wx.EVT_CHOICE, self.OnWindowLeave)
         self.cbShowShipBrowserTooltip.Bind(wx.EVT_CHECKBOX, self.OnWindowLeave)
         self.editSearchLimit.Bind(wx.EVT_LEAVE_WINDOW, self.OnWindowLeave)
+        self.intDelay.Bind(wx.lib.intctrl.EVT_INT, self.OnWindowLeave)
+        self.editSearchLimit.Bind(wx.lib.intctrl.EVT_INT, self.OnWindowLeave)
 
         self.cbRackLabels.Enable(self.sFit.serviceFittingOptions["rackSlots"] or False)
 
@@ -165,6 +186,7 @@ class PFGeneralPref(PreferenceView):
         self.sFit.serviceFittingOptions["showShipBrowserTooltip"] = self.cbShowShipBrowserTooltip.GetValue()
         # Item Search Limit
         self.generalSettings.set('itemSearchLimit', int(self.editSearchLimit.GetValue()))
+        self.generalSettings.set('marketSearchDelay', int(self.intDelay.GetValue()))
 
         fitID = self.mainFrame.getActiveFit()
         if fitID:

--- a/gui/builtinViewColumns/price.py
+++ b/gui/builtinViewColumns/price.py
@@ -45,8 +45,7 @@ class Price(ViewColumn):
             if stuff.isEmpty:
                 return ""
 
-        sPrice = ServicePrice.getInstance()
-        price = sPrice.getPriceNow(stuff.item)
+        price = stuff.item.price.price
 
         if not price:
             return ""
@@ -60,7 +59,7 @@ class Price(ViewColumn):
         sPrice = ServicePrice.getInstance()
 
         def callback(item):
-            price = sPrice.getPriceNow(item.ID)
+            price = item.item.price
             text = formatAmount(price.price, 3, 3, 9, currency=True) if price.price else ""
             if price.failed:
                 text += " (!)"

--- a/gui/builtinViews/fittingView.py
+++ b/gui/builtinViews/fittingView.py
@@ -482,6 +482,7 @@ class FittingView(d.Display):
                     # This only happens when turning on/off slot divisions
                     self.populate(self.mods)
                 self.refresh(self.mods)
+                self.Refresh()
 
             self.Show(self.activeFitID is not None and self.activeFitID == event.fitID)
         except wx._core.PyDeadObjectError:

--- a/gui/builtinViews/fittingView.py
+++ b/gui/builtinViews/fittingView.py
@@ -267,17 +267,19 @@ class FittingView(d.Display):
         We also refresh the fit of the new current page in case
         delete fit caused change in stats (projected)
         """
-        if event.fitID == self.getActiveFit():
+        active_fit_id = self.getActiveFit()
+        if event.fitID == active_fit_id:
             self.parent.DeletePage(self.parent.GetPageIndex(self))
 
         try:
             # Sometimes there is no active page after deletion, hence the try block
             sFit = Fit.getInstance()
-            fit = sFit.getFit(self.getActiveFit())
-            sFit.recalc(fit)
-            wx.PostEvent(self.mainFrame, GE.FitChanged(fitID=self.activeFitID))
+            fit = sFit.getFit(active_fit_id)
+            if fit.ID != event.fitID:
+                sFit.recalc(fit)
+                wx.PostEvent(self.mainFrame, GE.FitChanged(fitID=self.activeFitID))
         except wx._core.PyDeadObjectError:
-            pyfalog.error("Caught dead object")
+            pyfalog.error("Caught dead object on fit removed")
             pass
 
         event.Skip()
@@ -486,7 +488,7 @@ class FittingView(d.Display):
 
             self.Show(self.activeFitID is not None and self.activeFitID == event.fitID)
         except wx._core.PyDeadObjectError:
-            pyfalog.error("Caught dead object")
+            pyfalog.error("Caught dead object on fit change")
         finally:
             event.Skip()
 

--- a/gui/chromeTabs.py
+++ b/gui/chromeTabs.py
@@ -277,10 +277,8 @@ class PFNotebook(wx.Panel):
             """
             We used to try and get the current tab using:
             sel = self.tabsContainer.GetSelected()
-    
             But there's a race condition that causes it to give us back the wrong tab.
             Now we get the tab using a little basic math.
-    
             See GH #1055
             """
             if page_count == 1:

--- a/gui/itemStats.py
+++ b/gui/itemStats.py
@@ -531,6 +531,10 @@ class ItemParams(wx.Panel):
 
 class ItemCompare(wx.Panel):
     def __init__(self, parent, stuff, item, items, context=None):
+        # Start dealing with Price stuff to get that thread going
+        sPrice = ServicePrice.getInstance()
+        sPrice.getPrices(items, self.UpdateList)
+
         wx.Panel.__init__(self, parent)
         mainSizer = wx.BoxSizer(wx.VERTICAL)
 
@@ -587,11 +591,10 @@ class ItemCompare(wx.Panel):
                                              wx.DefaultSize, 0)
         bSizer.Add(self.toggleViewBtn, 0, wx.ALIGN_CENTER_VERTICAL)
 
-        if stuff is not None:
-            self.refreshBtn = wx.Button(self, wx.ID_ANY, u"Refresh", wx.DefaultPosition, wx.DefaultSize,
-                                        wx.BU_EXACTFIT)
-            bSizer.Add(self.refreshBtn, 0, wx.ALIGN_CENTER_VERTICAL)
-            self.refreshBtn.Bind(wx.EVT_BUTTON, self.RefreshValues)
+        self.refreshBtn = wx.Button(self, wx.ID_ANY, u"Refresh", wx.DefaultPosition, wx.DefaultSize,
+                                    wx.BU_EXACTFIT)
+        bSizer.Add(self.refreshBtn, 0, wx.ALIGN_CENTER_VERTICAL)
+        self.refreshBtn.Bind(wx.EVT_BUTTON, self.RefreshValues)
 
         mainSizer.Add(bSizer, 0, wx.ALIGN_RIGHT)
 
@@ -606,7 +609,8 @@ class ItemCompare(wx.Panel):
         self.PopulateList(event.Column)
         self.Thaw()
 
-    def UpdateList(self):
+    def UpdateList(self, items=None):
+        # We do nothing with `items`, but it gets returned by the price service thread
         self.Freeze()
         self.paramList.ClearAll()
         self.PopulateList()
@@ -676,9 +680,8 @@ class ItemCompare(wx.Panel):
 
                     self.paramList.SetStringItem(i, x + 1, valueUnit)
 
-                # Add prices
-                sPrice = ServicePrice.getInstance()
-                self.paramList.SetStringItem(i, len(self.attrs) + 1, formatAmount(sPrice.getPriceNow(item), 3, 3, 9, currency=True))
+            # Add prices
+            self.paramList.SetStringItem(i, len(self.attrs) + 1, formatAmount(item.price.price, 3, 3, 9, currency=True))
 
         self.paramList.RefreshRows()
         self.Layout()

--- a/gui/notesView.py
+++ b/gui/notesView.py
@@ -42,6 +42,7 @@ class NotesView(wx.Panel):
     def delayedSave(self, event):
         sFit = Fit.getInstance()
         fit = sFit.getFit(self.lastFitId)
-        newNotes = self.editNotes.GetValue()
-        fit.notes = newNotes
-        wx.PostEvent(self.mainFrame, GE.FitChanged(fitID=fit.ID))
+        if fit:
+            newNotes = self.editNotes.GetValue()
+            fit.notes = newNotes
+            wx.PostEvent(self.mainFrame, GE.FitChanged(fitID=fit.ID))

--- a/gui/shipBrowser.py
+++ b/gui/shipBrowser.py
@@ -1758,7 +1758,7 @@ class FitItem(SFItem.SFBrowserItem):
             self.deleted = True
 
         sFit = Fit.getInstance()
-        fit = sFit.getFit(self.fitID)
+        fit = sFit.getFit(self.fitID, basic=True)
 
         sFit.deleteFit(self.fitID)
 

--- a/gui/updateDialog.py
+++ b/gui/updateDialog.py
@@ -26,7 +26,7 @@ from service.settings import UpdateSettings as svc_UpdateSettings
 
 class UpdateDialog(wx.Dialog):
     def __init__(self, parent, release):
-        wx.Dialog.__init__(self, parent, id=wx.ID_ANY, title="Pyfa Update", pos=wx.DefaultPosition,
+        wx.Dialog.__init__(self, parent, id=wx.ID_ANY, title="Pyfa.fit Update", pos=wx.DefaultPosition,
                            size=wx.Size(400, 300), style=wx.DEFAULT_DIALOG_STYLE)
 
         self.UpdateSettings = svc_UpdateSettings.getInstance()
@@ -37,7 +37,7 @@ class UpdateDialog(wx.Dialog):
 
         headSizer = wx.BoxSizer(wx.HORIZONTAL)
 
-        self.headingText = wx.StaticText(self, wx.ID_ANY, "Pyfa Update Available!", wx.DefaultPosition, wx.DefaultSize,
+        self.headingText = wx.StaticText(self, wx.ID_ANY, "Pyfa.fit Update Available!", wx.DefaultPosition, wx.DefaultSize,
                                          wx.ALIGN_CENTRE)
         self.headingText.Wrap(-1)
         self.headingText.SetFont(wx.Font(14, 74, 90, 92, False))

--- a/service/fit.py
+++ b/service/fit.py
@@ -218,10 +218,12 @@ class Fit(object):
         if fit is None:
             fit = eos.db.getFit(fitID)
 
-        if fit not in self.fit_pointer_list:
+        if fit and fit not in self.fit_pointer_list:
             self.fit_pointer_list.append(fit)
 
         if basic:
+            return fit
+        elif fit is None:
             return fit
 
         inited = getattr(fit, "inited", None)

--- a/service/settings.py
+++ b/service/settings.py
@@ -359,6 +359,7 @@ class GeneralSettings(object):
         # 2 - Full View
         GeneralDefaultSettings = {
             "itemSearchLimit": 150,
+            "marketSearchDelay": 250,
         }
 
         self.serviceGeneralDefaultSettings = SettingsProvider.getInstance().getSettings("pyfaGeneralSettings", GeneralDefaultSettings)


### PR DESCRIPTION
## New Features
- *Market Search Delay*: Adds new feature cherry picked from @blitzmann where the market search has a short pause before it's triggered.  This means if you're a fast typer, you won't queue up 10 market searches.
- *Fire Cap Boosters at Percentage*: New preference item that allows you to only fire off cap boosters when you hit a certain percentage.  This defaults to 25%, can be adjusted through preferences.  More info below.

## Boring Technical Stuff
- Refactor the way we do calculations to handle cyclical recursion issues.
- Don't try and do stuff with notes when there is no fit. Thanks Redhand for reporting.
- Bugfixes with price handling
- Bugfixes when deleting objects
- Improvements to item compare window performance

## Detailed Feature Information

Currently we blindly and madly fire off all the things every opportunity we get.  Especially for capacitor boosters, this is wasteful.  

First, we peak at around 25% (+-3-4% depending on the fit), so by firing at 80% instead of 20% we're wasting a lot of ticks that we could get much higher regen numbers.  

Secondly, we waste a bunch of charge power, especially with large charges.  So let's add a feature for that!
![](https://puu.sh/vi2zL/72f1aa5724.png "")

Here's how a Golem with a cap booster looks currently:
![](https://puu.sh/vi1wn/7425a90751.png "")


And here's how it looks with a fire at percentage of 25%:
![](https://puu.sh/vi2ws/d88672bcb6.png "")

You'll notice that our stability goes _down_.  That's because we're waiting until we hit 25% before firing our cap booster off.  This will be much more accurate to how players use cap boosters, and greatly improve capsim accuracy.
