### PR TITLE
Bugfix: Stacktrace on fit delete

### DIFF
--- a/eos/db/saveddata/queries.py
+++ b/eos/db/saveddata/queries.py
@@ -521,6 +521,8 @@ def save(stuff):
 def remove(stuff):
     removeCachedEntry(type(stuff), stuff.ID)
     with sd_lock:
+        # Merge the object to make sure we don't already have it in session
+        saveddata_session.merge(stuff)
         saveddata_session.delete(stuff)
     commit()
 

--- a/gui/shipBrowser.py
+++ b/gui/shipBrowser.py
@@ -1758,7 +1758,7 @@ class FitItem(SFItem.SFBrowserItem):
             self.deleted = True
 
         sFit = Fit.getInstance()
-        fit = sFit.getFit(self.fitID)
+        fit = sFit.getFit(self.fitID, basic=True)
 
         sFit.deleteFit(self.fitID)
 


### PR DESCRIPTION
Merge our session to make sure we aren't trying to work with a different instance of the same object.  Also, don't recalc when deleting objects.