### PR TITLE
Enhancement: Control font size of stat pane

### DIFF
--- a/gui/builtinPreferenceViews/pyfaGeneralPreferences.py
+++ b/gui/builtinPreferenceViews/pyfaGeneralPreferences.py
@@ -121,6 +121,18 @@ class PFGeneralPref(PreferenceView):
 
         mainSizer.Add(searchLimitSizer, 0, wx.ALL | wx.EXPAND, 0)
 
+        # Font size
+        fontSizeSizer = wx.BoxSizer(wx.HORIZONTAL)
+
+        self.stDefaultFontSize = wx.StaticText(panel, wx.ID_ANY, u"Default font size (requires restart):", wx.DefaultPosition, wx.DefaultSize, 0)
+        self.stDefaultFontSize.Wrap(-1)
+        fontSizeSizer.Add(self.stDefaultFontSize, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
+
+        self.chFontSize = wx.Choice(panel, choices=['SMALL', 'NORMAL', 'LARGE'])
+        fontSizeSizer.Add(self.chFontSize, 1, wx.ALL | wx.EXPAND, 5)
+
+        mainSizer.Add(fontSizeSizer, 0, wx.ALL | wx.EXPAND, 0)
+
         self.cbGlobalChar.SetValue(self.sFit.serviceFittingOptions["useGlobalCharacter"])
         self.cbGlobalDmgPattern.SetValue(self.sFit.serviceFittingOptions["useGlobalDamagePattern"])
         self.cbFitColorSlots.SetValue(self.sFit.serviceFittingOptions["colorFitBySlot"] or False)
@@ -137,6 +149,7 @@ class PFGeneralPref(PreferenceView):
         self.cbShowShipBrowserTooltip.SetValue(self.sFit.serviceFittingOptions["showShipBrowserTooltip"])
         self.intDelay.SetValue(self.generalSettings.get("marketSearchDelay"))
         self.editSearchLimit.SetValue(int(self.generalSettings.get("itemSearchLimit")))
+        self.chFontSize.SetStringSelection(self.generalSettings.get("fontSize"))
 
         self.cbGlobalChar.Bind(wx.EVT_CHECKBOX, self.OnWindowLeave)
         self.cbGlobalDmgPattern.Bind(wx.EVT_CHECKBOX, self.OnWindowLeave)
@@ -155,6 +168,7 @@ class PFGeneralPref(PreferenceView):
         self.editSearchLimit.Bind(wx.EVT_LEAVE_WINDOW, self.OnWindowLeave)
         self.intDelay.Bind(wx.lib.intctrl.EVT_INT, self.OnWindowLeave)
         self.editSearchLimit.Bind(wx.lib.intctrl.EVT_INT, self.OnWindowLeave)
+        self.chFontSize.Bind(wx.lib.intctrl.EVT_INT, self.OnWindowLeave)
 
         self.cbRackLabels.Enable(self.sFit.serviceFittingOptions["rackSlots"] or False)
 
@@ -184,6 +198,7 @@ class PFGeneralPref(PreferenceView):
         # Item Search Limit
         self.generalSettings.set('itemSearchLimit', int(self.editSearchLimit.GetValue()))
         self.generalSettings.set('marketSearchDelay', int(self.intDelay.GetValue()))
+        self.generalSettings.set('fontSize', self.chFontSize.GetString(self.chFontSize.GetSelection()))
 
         fitID = self.mainFrame.getActiveFit()
         if fitID:

--- a/gui/statsPane.py
+++ b/gui/statsPane.py
@@ -21,7 +21,7 @@
 import wx
 
 from service.fit import Fit
-from service.settings import StatViewSettings
+from service.settings import StatViewSettings, GeneralSettings
 import gui.mainFrame
 import gui.builtinStatsViews
 import gui.globalEvents as GE
@@ -78,14 +78,10 @@ class StatsPane(wx.Panel):
     def __init__(self, parent):
         wx.Panel.__init__(self, parent)
 
-        # Use 25% smaller fonts if MAC or force font size to 8 for msw/linux
+        general_settings = GeneralSettings.getInstance()
 
-        if "__WXMAC__" in wx.PlatformInfo:
-            self.SetWindowVariant(wx.WINDOW_VARIANT_SMALL)
-        else:
-            standardFont = wx.SystemSettings.GetFont(wx.SYS_DEFAULT_GUI_FONT)
-            standardFont.SetPointSize(8)
-            self.SetFont(standardFont)
+        # Set the font size used on the stats pane
+        self.SetWindowVariant(getattr(wx, 'WINDOW_VARIANT_' + general_settings.get('fontSize'), wx.WINDOW_VARIANT_NORMAL))
 
         mainSizer = wx.BoxSizer(wx.VERTICAL)
         self.SetSizer(mainSizer)

--- a/service/settings.py
+++ b/service/settings.py
@@ -360,6 +360,7 @@ class GeneralSettings(object):
         GeneralDefaultSettings = {
             "itemSearchLimit": 150,
             "marketSearchDelay": 250,
+            "fontSize": 'NORMAL',
         }
 
         self.serviceGeneralDefaultSettings = SettingsProvider.getInstance().getSettings("pyfaGeneralSettings", GeneralDefaultSettings)


### PR DESCRIPTION
Instead of hard coding the stats pane, allow it to be dynamically set.

Can be extended later to other areas.

Small:
https://puu.sh/vjLfa/86d7658152.png

Normal (current):
https://puu.sh/vjLj3/a2b0f79a5f.png

Large:
https://puu.sh/vjLhy/f86fd51055.png