### PR TITLE
Enhancement: Allow additional overrides

### DIFF
--- a/config.py
+++ b/config.py
@@ -94,7 +94,9 @@ def defPaths(customSavePath):
     # The database where the static EVE data from the datadump is kept.
     # This is not the standard sqlite datadump but a modified version created by eos
     # maintenance script
-    gameDB = getPyfaPath(u"eve.db")
+    gameDB = getattr(configforced, "gameDB", gameDB)
+    if not gameDB:
+        gameDB = getPyfaPath(u"eve.db")
 
     # DON'T MODIFY ANYTHING BELOW
     import eos.config

--- a/service/settings.py
+++ b/service/settings.py
@@ -262,7 +262,7 @@ class HTMLExportSettings(object):
 
     def __init__(self):
         serviceHTMLExportDefaultSettings = {
-            "path"   : config.getPyfaPath(u'pyfaFits.html'),
+            "path"   : config.getSavePath(u'pyfaFits.html'),
             "minimal": False
         }
         self.serviceHTMLExportSettings = SettingsProvider.getInstance().getSettings(


### PR DESCRIPTION
Cherry picked from: https://github.com/pyfa-org/Pyfa/pull/1124

Move the default HTML export to the user share folder, and allows overriding the EVE.db.