### PR TITLE
Bugfix: Catch typo that causes annoying stacktrace

### DIFF
--- a/config.py
+++ b/config.py
@@ -25,7 +25,7 @@ debug = False
 saveInRoot = False
 
 # Version data
-version = "2017.04.16"
+version = "2017.04.17"
 if hasattr(sys, 'frozen'):
     tag = "(release)"
 else:

--- a/gui/builtinStatsViews/rechargeViewFull.py
+++ b/gui/builtinStatsViews/rechargeViewFull.py
@@ -135,7 +135,7 @@ class RechargeViewFull(StatsView):
             label = getattr(self, "labelTankReinforcedShieldPassive")
             value = fit.effectiveTank["passiveShield"] if self.effective else fit.tank["passiveShield"]
             label.SetLabel(formatAmount(value, 3, 0, 9))
-            unitlbl = getattr(self, "unitlabelTankReinforcedShieldPassive")
+            unitlbl = getattr(self, "unitLabelTankReinforcedShieldPassive")
             unitlbl.SetLabel(unit)
 
         else:


### PR DESCRIPTION
Fixes an issue where we're looking for `label` instead of `Label`.  Fairly harmless, but causes an annoying stacktrace.