### PR TITLE
Bugfix: Context menu

### DIFF
--- a/gui/implantView.py
+++ b/gui/implantView.py
@@ -212,4 +212,8 @@ class ImplantDisplay(d.Display):
             context = (("implantView",),)
             menu = ContextMenu.getMenu([], *context)
         if menu is not None:
-            self.PopupMenu(menu)
+            try:
+                self.PopupMenu(menu)
+            except:
+                # Sometimes the menu is destroyed before it's fully loaded, so don't throw an error when this happens.
+                pass

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,7 @@ requests == 2.11.1
 sqlalchemy >= 1.0.5
 EVE_Gnosis
 multiprocess >= 0.70.5
+pyswagger
+six
+pytz
+esipy


### PR DESCRIPTION
Trap errors if the menu is destroyed before being fully created