### PR TITLE
Bugfix: Remote Rep Drones

### DIFF
--- a/eos/saveddata/drone.py
+++ b/eos/saveddata/drone.py
@@ -101,10 +101,6 @@ class Drone(HandledItem, HandledCharge, ItemAttrShortcut, ChargeAttrShortcut):
         return self.__charge
 
     @property
-    def cycleTime(self):
-        return max(self.getModifiedItemAttr("duration"), 0)
-
-    @property
     def dealsDamage(self):
         for attr in ("emDamage", "kineticDamage", "explosiveDamage", "thermalDamage"):
             if attr in self.itemModifiedAttributes or attr in self.chargeModifiedAttributes:

--- a/eos/saveddata/drone.py
+++ b/eos/saveddata/drone.py
@@ -101,6 +101,10 @@ class Drone(HandledItem, HandledCharge, ItemAttrShortcut, ChargeAttrShortcut):
         return self.__charge
 
     @property
+    def cycleTime(self):
+        return max(self.getModifiedItemAttr("duration"), 0)
+
+    @property
     def dealsDamage(self):
         for attr in ("emDamage", "kineticDamage", "explosiveDamage", "thermalDamage"):
             if attr in self.itemModifiedAttributes or attr in self.chargeModifiedAttributes:

--- a/eos/saveddata/fit.py
+++ b/eos/saveddata/fit.py
@@ -1191,14 +1191,16 @@ class Fit(object):
         if force_recalc is False:
             return self.__remoteReps
 
-        # We are rerunning the recalcs. Explicitly set to 0 to make sure we don't duplicate anything and correctly
-        # set all values to 0.
+        # We are rerunning the recalcs. Explicitly set to 0 to make sure we don't duplicate anything and correctly set all values to 0.
         for remote_type in self.__remoteReps:
             self.__remoteReps[remote_type] = 0
 
         for stuff in chain(self.modules, self.drones):
             remote_type = None
-            modifier = stuff.getModifiedItemAttr("chargedArmorDamageMultiplier", 1)
+            if stuff.charge:
+                fueledMultiplier = stuff.getModifiedItemAttr("chargedArmorDamageMultiplier", 1)
+            else:
+                fueledMultiplier = 1
 
             if isinstance(stuff, Module) and (stuff.isEmpty or stuff.state < State.ACTIVE):
                 continue
@@ -1253,7 +1255,7 @@ class Fit(object):
                     hp = droneHull
                 else:
                     hp = 0
-            self.__remoteReps[remote_type] += (hp * modifier) / duration
+            self.__remoteReps[remote_type] += (hp * fueledMultiplier) / duration
 
         return self.__remoteReps
 

--- a/eos/saveddata/fit.py
+++ b/eos/saveddata/fit.py
@@ -30,6 +30,7 @@ import eos.db
 from eos.effectHandlerHelpers import HandledModuleList, HandledDroneCargoList, HandledImplantBoosterList, HandledProjectedDroneList, HandledProjectedModList
 from eos.enum import Enum
 from eos.saveddata.ship import Ship
+from eos.saveddata.drone import Drone
 from eos.saveddata.character import Character
 from eos.saveddata.citadel import Citadel
 from eos.saveddata.module import Module, State, Slot
@@ -1190,23 +1191,27 @@ class Fit(object):
         if force_recalc is False:
             return self.__remoteReps
 
-        # We are rerunning the recalcs. Explicitly set to 0 to make sure we don't duplicate anything and correctly set all values to 0.
+        # We are rerunning the recalcs. Explicitly set to 0 to make sure we don't duplicate anything and correctly
+        # set all values to 0.
         for remote_type in self.__remoteReps:
             self.__remoteReps[remote_type] = 0
 
-        for module in self.modules:
-            # Skip empty and non-Active modules
-            if module.isEmpty or module.state < State.ACTIVE:
+        for stuff in chain(self.modules, self.drones):
+            remote_type = None
+            modifier = stuff.getModifiedItemAttr("chargedArmorDamageMultiplier", 1)
+
+            if isinstance(stuff, Module) and (stuff.isEmpty or stuff.state < State.ACTIVE):
                 continue
+            elif isinstance(stuff, Drone):
+                # drones don't have fueled charges, so siomply override modifier with the amount of drones active
+                modifier = stuff.amountActive
 
             # Covert cycleTime to seconds
-            duration = module.cycleTime / 1000
+            duration = stuff.cycleTime / 1000
 
             # Skip modules with no duration.
             if not duration:
                 continue
-
-            fueledMultiplier = module.getModifiedItemAttr("chargedArmorDamageMultiplier", 1)
 
             remote_module_groups = {
                 "Remote Armor Repairer"          : "Armor",
@@ -1217,26 +1222,38 @@ class Fit(object):
                 "Remote Capacitor Transmitter"   : "Capacitor",
             }
 
-            module_group = module.item.group.name
+            module_group = stuff.item.group.name
 
             if module_group in remote_module_groups:
                 remote_type = remote_module_groups[module_group]
-            else:
+            elif not isinstance(stuff, Drone):
                 # Module isn't in our list of remote rep modules, bail
                 continue
 
             if remote_type == "Hull":
-                hp = module.getModifiedItemAttr("structureDamageAmount", 0)
+                hp = stuff.getModifiedItemAttr("structureDamageAmount", 0)
             elif remote_type == "Armor":
-                hp = module.getModifiedItemAttr("armorDamageAmount", 0)
+                hp = stuff.getModifiedItemAttr("armorDamageAmount", 0)
             elif remote_type == "Shield":
-                hp = module.getModifiedItemAttr("shieldBonus", 0)
+                hp = stuff.getModifiedItemAttr("shieldBonus", 0)
             elif remote_type == "Capacitor":
-                hp = module.getModifiedItemAttr("powerTransferAmount", 0)
+                hp = stuff.getModifiedItemAttr("powerTransferAmount", 0)
             else:
-                hp = 0
-
-            self.__remoteReps[remote_type] += (hp * fueledMultiplier) / duration
+                droneShield = stuff.getModifiedItemAttr("shieldBonus", 0)
+                droneArmor = stuff.getModifiedItemAttr("armorDamageAmount", 0)
+                droneHull = stuff.getModifiedItemAttr("structureDamageAmount", 0)
+                if droneShield:
+                    remote_type = "Shield"
+                    hp = droneShield
+                elif droneArmor:
+                    remote_type = "Armor"
+                    hp = droneArmor
+                elif droneHull:
+                    remote_type = "Hull"
+                    hp = droneHull
+                else:
+                    hp = 0
+            self.__remoteReps[remote_type] += (hp * modifier) / duration
 
         return self.__remoteReps
 

--- a/eos/saveddata/fit.py
+++ b/eos/saveddata/fit.py
@@ -1202,11 +1202,11 @@ class Fit(object):
             else:
                 fueledMultiplier = 1
 
-            if isinstance(stuff, Module) and (stuff.isEmpty or stuff.state < State.ACTIVE):
-                continue
-            elif isinstance(stuff, Drone):
-                # drones don't have fueled charges, so siomply override modifier with the amount of drones active
-                modifier = stuff.amountActive
+            if isinstance(stuff, Drone):
+                # We only get one drone object, but may have multiple drones.  Add a multiplier so we get the correct total value.
+                count = stuff.amountActive
+            else:
+                count = 1
 
             # Covert cycleTime to seconds
             duration = stuff.cycleTime / 1000
@@ -1255,7 +1255,7 @@ class Fit(object):
                     hp = droneHull
                 else:
                     hp = 0
-            self.__remoteReps[remote_type] += (hp * fueledMultiplier) / duration
+            self.__remoteReps[remote_type] += (hp * fueledMultiplier * count) / duration
 
         return self.__remoteReps
 

--- a/gui/builtinViewColumns/misc.py
+++ b/gui/builtinViewColumns/misc.py
@@ -29,6 +29,7 @@ from gui.utils.numberFormatter import formatAmount
 from gui.utils.listFormatter import formatList
 from eos.saveddata.drone import Drone
 
+
 class Miscellanea(ViewColumn):
     name = "Miscellanea"
 

--- a/gui/builtinViewColumns/misc.py
+++ b/gui/builtinViewColumns/misc.py
@@ -27,7 +27,7 @@ from gui.viewColumn import ViewColumn
 from gui.bitmapLoader import BitmapLoader
 from gui.utils.numberFormatter import formatAmount
 from gui.utils.listFormatter import formatList
-
+from eos.saveddata.drone import Drone
 
 class Miscellanea(ViewColumn):
     name = "Miscellanea"
@@ -419,7 +419,11 @@ class Miscellanea(ViewColumn):
             cycleTime = stuff.cycleTime
             if not repAmount or not cycleTime:
                 return "", None
-            repPerSec = float(repAmount) * 1000 / cycleTime
+            repPerSecPerDrone = repPerSec = float(repAmount) * 1000 / cycleTime
+
+            if isinstance(stuff, Drone):
+                repPerSec *= stuff.amount
+
             text = "{0}/s".format(formatAmount(repPerSec, 3, 0, 3))
             ttEntries = []
             if hullAmount is not None and repAmount == hullAmount:
@@ -428,7 +432,8 @@ class Miscellanea(ViewColumn):
                 ttEntries.append("armor")
             if shieldAmount is not None and repAmount == shieldAmount:
                 ttEntries.append("shield")
-            tooltip = "{0} repaired per second".format(formatList(ttEntries)).capitalize()
+
+            tooltip = "{0} HP repaired per second\n{1} HP/s per drone".format(formatList(ttEntries).capitalize(), repPerSecPerDrone)
             return text, tooltip
         elif itemGroup == "Energy Neutralizer Drone":
             neutAmount = stuff.getModifiedItemAttr("energyNeutralizerAmount")


### PR DESCRIPTION
Fixes remote rep drones, showing the total rep amount and adding them to the remote rep pane.

Also, bugfix with fueled multiplier always applying (even when no charges).