### PR TITLE
Enhancement: User Updatable Database

### DIFF
--- a/config.py
+++ b/config.py
@@ -39,6 +39,8 @@ savePath = None
 saveDB = None
 gameDB = None
 logPath = None
+gamedatabasename = None
+esiurl = None
 
 
 def isFrozen():
@@ -60,6 +62,7 @@ def defPaths(customSavePath):
     global saveDB
     global gameDB
     global saveInRoot
+    global gamedatabasename
 
     pyfalog.debug("Configuring Pyfa")
 
@@ -96,7 +99,7 @@ def defPaths(customSavePath):
     # maintenance script
     gameDB = getattr(configforced, "gameDB", gameDB)
     if not gameDB:
-        gameDB = getPyfaPath(u"eve.db")
+        gameDB = getPyfaPath(unicode(gamedatabasename))
 
     # DON'T MODIFY ANYTHING BELOW
     import eos.config

--- a/eos/db/gamedata/item.py
+++ b/eos/db/gamedata/item.py
@@ -27,7 +27,7 @@ from eos.gamedata import Attribute, Effect, Group, Icon, Item, MetaType, Traits
 
 items_table = Table("invtypes", gamedata_meta,
                     Column("typeID", Integer, primary_key=True),
-                    Column("typeName", String, index=True),
+                    Column("typeName", String),
                     Column("description", String),
                     Column("raceID", Integer),
                     Column("factionID", Integer),

--- a/eos/db/gamedata/queries.py
+++ b/eos/db/gamedata/queries.py
@@ -92,7 +92,8 @@ def getItem(lookfor, eager=None):
         else:
             # Item names are unique, so we can use first() instead of one()
             item = gamedata_session.query(Item).options(*processEager(eager)).filter(Item.name == lookfor).first()
-            itemNameMap[lookfor] = item.ID
+            if item:
+                itemNameMap[lookfor] = item.ID
     else:
         raise TypeError("Need integer or string as argument")
     return item

--- a/eos/db/gamedata/queries.py
+++ b/eos/db/gamedata/queries.py
@@ -21,7 +21,7 @@ from sqlalchemy.orm import join, exc
 from sqlalchemy.sql import and_, or_, select
 
 import eos.config
-from eos.db import gamedata_session, sd_lock
+from eos.db import gamedata_session
 from eos.db.gamedata.metaGroup import metatypes_table, items_table
 from eos.db.gamedata.group import groups_table
 from eos.db.util import processEager, processWhere
@@ -324,17 +324,3 @@ def directAttributeRequest(itemIDs, attrIDs):
 
     result = gamedata_session.execute(q).fetchall()
     return result
-
-def add(stuff):
-    with sd_lock:
-        gamedata_session.add(stuff)
-
-
-def save(stuff):
-    add(stuff)
-    commit()
-
-def commit():
-    with sd_lock:
-        gamedata_session.commit()
-        gamedata_session.flush()

--- a/eos/db/gamedata/queries.py
+++ b/eos/db/gamedata/queries.py
@@ -213,6 +213,15 @@ def getMarketGroup(lookfor, eager=None):
     return marketGroup
 
 
+@cachedQuery(1, "lookfor")
+def getAllMarketGroups(eager=None):
+    if eager is None:
+        marketGroups = gamedata_session.query(MarketGroup).all()
+    else:
+        marketGroups = gamedata_session.query(MarketGroup).options(*processEager(eager)).first()
+    return marketGroups
+
+
 @cachedQuery(2, "where", "filter")
 def getItemsByCategory(filter, where=None, eager=None):
     if isinstance(filter, int):

--- a/eos/db/gamedata/queries.py
+++ b/eos/db/gamedata/queries.py
@@ -21,7 +21,7 @@ from sqlalchemy.orm import join, exc
 from sqlalchemy.sql import and_, or_, select
 
 import eos.config
-from eos.db import gamedata_session
+from eos.db import gamedata_session, sd_lock
 from eos.db.gamedata.metaGroup import metatypes_table, items_table
 from eos.db.gamedata.group import groups_table
 from eos.db.util import processEager, processWhere
@@ -315,3 +315,17 @@ def directAttributeRequest(itemIDs, attrIDs):
 
     result = gamedata_session.execute(q).fetchall()
     return result
+
+def add(stuff):
+    with sd_lock:
+        gamedata_session.add(stuff)
+
+
+def save(stuff):
+    add(stuff)
+    commit()
+
+def commit():
+    with sd_lock:
+        gamedata_session.commit()
+        gamedata_session.flush()

--- a/eos/db/saveddata/databaseRepair.py
+++ b/eos/db/saveddata/databaseRepair.py
@@ -32,8 +32,8 @@ class DatabaseCleanup(object):
         try:
             results = saveddata_engine.execute(query)
             return results
-        except DatabaseError:
-            pyfalog.error("Failed to connect to database or error executing query:\n{0}", query)
+        except DatabaseError as e:
+            pyfalog.error("Failed to connect to database or error executing query:\n{0}\n{1}", query, e)
             return None
 
     @staticmethod

--- a/eos/gamedata.py
+++ b/eos/gamedata.py
@@ -278,7 +278,7 @@ class Item(EqBase):
 
             self.attributes[key].value = value
             return True
-        except:
+        except (AttributeError, KeyError):
             return False
 
     def isType(self, type):

--- a/eos/gamedata.py
+++ b/eos/gamedata.py
@@ -270,6 +270,17 @@ class Item(EqBase):
         else:
             return default
 
+    def setAttribute(self, key, value):
+        try:
+            if key not in self.attributes:
+                # TODO: Add values in if missing
+                self.attributes.append(key)
+
+            self.attributes[key].value = value
+            return True
+        except:
+            return False
+
     def isType(self, type):
         for effect in self.effects.itervalues():
             if effect.isType(type):

--- a/eos/saveddata/module.py
+++ b/eos/saveddata/module.py
@@ -696,7 +696,7 @@ class Module(HandledItem, HandledCharge, ItemAttrShortcut, ChargeAttrShortcut):
             """
             effective_reload_time = raw_reload_time
 
-        if numShots > 0 and self.charge:
+        if numShots and self.charge:
             speed = (speed * numShots + effective_reload_time) / numShots
 
         return speed

--- a/gui/builtinPreferenceViews/pyfaDatabasePreferences.py
+++ b/gui/builtinPreferenceViews/pyfaDatabasePreferences.py
@@ -1,4 +1,5 @@
 import wx
+from wx.lib.intctrl import IntCtrl
 
 from gui.preferenceView import PreferenceView
 from gui.bitmapLoader import BitmapLoader
@@ -6,14 +7,20 @@ from gui.utils import helpers_wxPython as wxHelpers
 import config
 from eos.db.saveddata.queries import clearPrices, clearDamagePatterns, clearTargetResists
 from eos.db.saveddata.loadDefaultDatabaseValues import DefaultDatabaseValues
+from service.settings import DatabaseSettings
+from service.esi import esiItems, esiDogma
+import sys
 
 import logging
 
 logger = logging.getLogger(__name__)
 
 
-class PFGeneralPref(PreferenceView):
+class PFDatabasePref(PreferenceView):
     title = "Database"
+
+    def __init__(self):
+        self.databaseSettings = DatabaseSettings.getInstance()
 
     def populatePanel(self, panel):
         self.dirtySettings = False
@@ -102,6 +109,52 @@ class PFGeneralPref(PreferenceView):
         self.btnDeleteTargetResists.Bind(wx.EVT_BUTTON, self.DeleteTargetResists)
         self.btnPrices.Bind(wx.EVT_BUTTON, self.DeletePrices)
 
+        self.m_staticline4 = wx.StaticLine(panel, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize, wx.LI_HORIZONTAL)
+        mainSizer.Add(self.m_staticline4, 0, wx.EXPAND | wx.TOP | wx.BOTTOM, 5)
+
+        self.stSubTitleTwo = wx.StaticText(panel, wx.ID_ANY, u"Update Game Data Database\n"
+                                                             u"Enabling these options will increase the length of time it takes to update.",
+                                        wx.DefaultPosition, wx.DefaultSize, 0)
+        self.stSubTitleTwo.Wrap(-1)
+        mainSizer.Add(self.stSubTitleTwo, 0, wx.ALL, 3)
+
+        self.m_staticline5 = wx.StaticLine(panel, wx.ID_ANY, wx.DefaultPosition, wx.DefaultSize, wx.LI_HORIZONTAL)
+        mainSizer.Add(self.m_staticline5, 0, wx.EXPAND | wx.TOP | wx.BOTTOM, 5)
+
+        self.btnUpdateDatabase = wx.Button(panel, wx.ID_ANY, u"Update Database", wx.DefaultPosition, wx.DefaultSize, 0)
+        mainSizer.Add(self.btnUpdateDatabase, 0, wx.ALL, 5)
+
+        self.cbImportItemsNotInMarketGroups = wx.CheckBox(panel, wx.ID_ANY, u"Import items not in market groups.",
+                                                    wx.DefaultPosition, wx.DefaultSize, 0)
+        mainSizer.Add(self.cbImportItemsNotInMarketGroups, 0, wx.ALL | wx.EXPAND, 5)
+
+        self.cbImportItemsNotPublished = wx.CheckBox(panel, wx.ID_ANY, u"Import items that are not published.",
+                                                    wx.DefaultPosition, wx.DefaultSize, 0)
+        mainSizer.Add(self.cbImportItemsNotPublished, 0, wx.ALL | wx.EXPAND, 5)
+
+        delayTimer = wx.BoxSizer(wx.HORIZONTAL)
+
+        self.stUpdateThreads = wx.StaticText(panel, wx.ID_ANY, u"Threads to use when updating the database:", wx.DefaultPosition, wx.DefaultSize, 0)
+        self.stUpdateThreads.Wrap(-1)
+        self.stUpdateThreads.SetToolTip(
+            wx.ToolTip('More threads may speed up updating the database, but typically little gain is seen above 25.'))
+
+        delayTimer.Add(self.stUpdateThreads, 0, wx.ALL | wx.ALIGN_CENTER_VERTICAL, 5)
+
+        self.intDelay = IntCtrl(panel, max=50, limited=True)
+        delayTimer.Add(self.intDelay, 0, wx.ALL, 5)
+
+        mainSizer.Add(delayTimer, 0, wx.ALL | wx.EXPAND, 0)
+
+        self.intDelay.SetValue(self.databaseSettings.get("UpdateThreads"))
+        self.cbImportItemsNotInMarketGroups.SetValue(self.databaseSettings.get("ImportItemsNotInMarketGroups"))
+        self.cbImportItemsNotPublished.SetValue(self.databaseSettings.get("ImportItemsNotPublished"))
+
+        self.btnUpdateDatabase.Bind(wx.EVT_BUTTON, self.UpdateDatabase)
+        self.intDelay.Bind(wx.lib.intctrl.EVT_INT, self.OnWindowLeave)
+        self.cbImportItemsNotInMarketGroups.Bind(wx.EVT_CHECKBOX, self.OnWindowLeave)
+        self.cbImportItemsNotPublished.Bind(wx.EVT_LEAVE_WINDOW, self.OnWindowLeave)
+
         panel.SetSizer(mainSizer)
         panel.Layout()
 
@@ -122,6 +175,18 @@ class PFGeneralPref(PreferenceView):
         if wxHelpers.YesNoDialog(question, u"Confirm"):
             clearPrices()
 
+    def UpdateDatabase(self, event):
+        question = u"This will take a significant amount of time.  Once the update is complete, Pyfa will restart.\n" \
+                   u"Pyfa will become unresponsive until the update is complete.  Would you like to proceed?"
+        if wxHelpers.YesNoDialog(question, u"Confirm"):
+            sESI = esiItems.getInstance()
+            sESI.updateTypes()
+            sDogma = esiDogma.getInstance()
+            sDogma.updateAllDogmaTables()
+
+            wxHelpers.OKDialog(u"Database upgrade completed successfully.\nPlease restart Pyfa.", u"Database Upgrade")
+            sys.exit()
+
     def onCBsaveInRoot(self, event):
         # We don't want users to be able to actually change this,
         # so if they try and change it, set it back to the current setting
@@ -135,5 +200,10 @@ class PFGeneralPref(PreferenceView):
     def getImage(self):
         return BitmapLoader.getBitmap("settings_database", "gui")
 
+    def OnWindowLeave(self, event):
+        self.databaseSettings.set('UpdateThreads', int(self.intDelay.GetValue()))
+        self.databaseSettings.set('ImportItemsNotInMarketGroups', int(self.cbImportItemsNotInMarketGroups.GetValue()))
+        self.databaseSettings.set("ImportItemsNotPublished", self.cbImportItemsNotPublished.GetValue())
 
-PFGeneralPref.register()
+
+PFDatabasePref.register()

--- a/gui/builtinPreferenceViews/pyfaDatabasePreferences.py
+++ b/gui/builtinPreferenceViews/pyfaDatabasePreferences.py
@@ -179,11 +179,14 @@ class PFDatabasePref(PreferenceView):
         question = u"This will take a significant amount of time.  Once the update is complete, Pyfa will restart.\n" \
                    u"Pyfa will become unresponsive until the update is complete.  Would you like to proceed?"
         if wxHelpers.YesNoDialog(question, u"Confirm"):
+            loadDlg = wxHelpers.PopupDialog(None, ("Updating..."), ("Updating database.\n\nPlease wait...."))
+
             sESI = esiItems.getInstance()
             sESI.updateTypes()
             sDogma = esiDogma.getInstance()
             sDogma.updateAllDogmaTables()
 
+            loadDlg.Destroy()
             wxHelpers.OKDialog(u"Database upgrade completed successfully.\nPlease restart Pyfa.", u"Database Upgrade")
             sys.exit()
 

--- a/gui/builtinPreferenceViews/pyfaGeneralPreferences.py
+++ b/gui/builtinPreferenceViews/pyfaGeneralPreferences.py
@@ -96,6 +96,10 @@ class PFGeneralPref(PreferenceView):
 
         mainSizer.Add(priceSizer, 0, wx.ALL | wx.EXPAND, 0)
 
+        self.cbShowAllMarketGroups = wx.CheckBox(panel, wx.ID_ANY, u"Show all market groups (requires restart)",
+                                                    wx.DefaultPosition, wx.DefaultSize, 0)
+        mainSizer.Add(self.cbShowAllMarketGroups, 0, wx.ALL | wx.EXPAND, 5)
+
         delayTimer = wx.BoxSizer(wx.HORIZONTAL)
 
         self.stMarketDelay = wx.StaticText(panel, wx.ID_ANY, u"Market Search Delay (ms):", wx.DefaultPosition, wx.DefaultSize, 0)
@@ -149,6 +153,7 @@ class PFGeneralPref(PreferenceView):
         self.cbShowShipBrowserTooltip.SetValue(self.sFit.serviceFittingOptions["showShipBrowserTooltip"])
         self.intDelay.SetValue(self.generalSettings.get("marketSearchDelay"))
         self.editSearchLimit.SetValue(int(self.generalSettings.get("itemSearchLimit")))
+        self.cbShowAllMarketGroups.SetValue(self.generalSettings.get("showAllMarketGroups"))
         self.chFontSize.SetStringSelection(self.generalSettings.get("fontSize"))
 
         self.cbGlobalChar.Bind(wx.EVT_CHECKBOX, self.OnWindowLeave)
@@ -168,6 +173,7 @@ class PFGeneralPref(PreferenceView):
         self.editSearchLimit.Bind(wx.EVT_LEAVE_WINDOW, self.OnWindowLeave)
         self.intDelay.Bind(wx.lib.intctrl.EVT_INT, self.OnWindowLeave)
         self.editSearchLimit.Bind(wx.lib.intctrl.EVT_INT, self.OnWindowLeave)
+        self.cbShowAllMarketGroups.Bind(wx.EVT_CHECKBOX, self.OnWindowLeave)
         self.chFontSize.Bind(wx.lib.intctrl.EVT_INT, self.OnWindowLeave)
 
         self.cbRackLabels.Enable(self.sFit.serviceFittingOptions["rackSlots"] or False)
@@ -194,10 +200,11 @@ class PFGeneralPref(PreferenceView):
         self.sFit.serviceFittingOptions["enableGaugeAnimation"] = self.cbGaugeAnimation.GetValue()
         self.sFit.serviceFittingOptions["exportCharges"] = self.cbExportCharges.GetValue()
         self.sFit.serviceFittingOptions["openFitInNew"] = self.cbOpenFitInNew.GetValue()
-        self.sFit.serviceFittingOptions["showShipBrowserTooltip"] = self.cbShowShipBrowserTooltip.GetValue()
+        self.sFit.serviceFittingOptions["showShipBrowserTooltip"] = self.cbShowAllMarketGroups.GetValue()
         # Item Search Limit
         self.generalSettings.set('itemSearchLimit', int(self.editSearchLimit.GetValue()))
         self.generalSettings.set('marketSearchDelay', int(self.intDelay.GetValue()))
+        self.generalSettings.set("showAllMarketGroups", self.cbShowShipBrowserTooltip.GetValue())
         self.generalSettings.set('fontSize', self.chFontSize.GetString(self.chFontSize.GetSelection()))
 
         fitID = self.mainFrame.getActiveFit()

--- a/gui/display.py
+++ b/gui/display.py
@@ -251,6 +251,8 @@ class Display(wx.ListCtrl):
 
                 newImageId = col.getImageId(st)
 
+                if newText is None:
+                    newText = ''
                 colItem.SetText(newText)
                 colItem.SetImage(newImageId)
 

--- a/gui/utils/helpers_wxPython.py
+++ b/gui/utils/helpers_wxPython.py
@@ -13,3 +13,33 @@ def OKDialog(question=u'Are you sure you want to do this?', caption=u'Yes or no?
     result = dlg.ShowModal() == wx.ID_OK
     dlg.Destroy()
     return result
+
+
+class PopupDialog(wx.Dialog):
+    """ A popup dialog for temporary user messages """
+
+    def __init__(self, parent, title, msg):
+        # Create a dialog
+        wx.Dialog.__init__(self, parent, -1, title, size=(350, 150), style=wx.CAPTION | wx.STAY_ON_TOP)
+        # Add sizers
+        box = wx.BoxSizer(wx.VERTICAL)
+        box2 = wx.BoxSizer(wx.HORIZONTAL)
+        # Add an Info graphic
+        bitmap = wx.EmptyBitmap(32, 32)
+        bitmap = wx.ArtProvider_GetBitmap(wx.ART_INFORMATION, wx.ART_MESSAGE_BOX, (32, 32))
+        graphic = wx.StaticBitmap(self, -1, bitmap)
+        box2.Add(graphic, 0, wx.EXPAND | wx.ALIGN_CENTER | wx.ALL, 10)
+        # Add the message
+        message = wx.StaticText(self, -1, msg)
+        box2.Add(message, 0, wx.EXPAND | wx.ALIGN_CENTER | wx.ALIGN_CENTER_VERTICAL | wx.ALL, 10)
+        box.Add(box2, 0, wx.EXPAND)
+        # Handle layout
+        self.SetAutoLayout(True)
+        self.SetSizer(box)
+        self.Fit()
+        self.Layout()
+        self.CentreOnScreen()
+        # Display the Dialog
+        self.Show()
+        # Make sure the screen gets fully drawn before continuing.
+        wx.Yield()

--- a/gui/utils/helpers_wxPython.py
+++ b/gui/utils/helpers_wxPython.py
@@ -6,3 +6,10 @@ def YesNoDialog(question=u'Are you sure you want to do this?', caption=u'Yes or 
     result = dlg.ShowModal() == wx.ID_YES
     dlg.Destroy()
     return result
+
+
+def OKDialog(question=u'Are you sure you want to do this?', caption=u'Yes or no?'):
+    dlg = wx.MessageDialog(None, question, caption, wx.OK | wx.ICON_INFORMATION)
+    result = dlg.ShowModal() == wx.ID_OK
+    dlg.Destroy()
+    return result

--- a/pyfa.py
+++ b/pyfa.py
@@ -176,8 +176,8 @@ parser.add_option("-d", "--debug", action="store_true", dest="debug", help="Set 
 parser.add_option("-t", "--title", action="store", dest="title", help="Set Window Title", default=None)
 parser.add_option("-s", "--savepath", action="store", dest="savepath", help="Set the folder for savedata", default=None)
 parser.add_option("-l", "--logginglevel", action="store", dest="logginglevel", help="Set desired logging level [Critical|Error|Warning|Info|Debug]", default="Error")
-parser.add_option("-esi", "--esiurl", action="store", dest="esiurl", help="Path to use for ESI.", default="https://esi.tech.ccp.is/latest/swagger.json?datasource=tranquility")
-parser.add_option("-gdb", "--gamedatadatabase", action="store", dest="gamedatadatabase", help="Name to use for the gamedata database", default="eve.db")
+parser.add_option("-e", "--esiurl", action="store", dest="esiurl", help="Path to use for ESI.", default="https://esi.tech.ccp.is/latest/swagger.json?datasource=tranquility")
+parser.add_option("-g", "--gamedatadatabase", action="store", dest="gamedatadatabase", help="Name to use for the gamedata database", default="eve.db")
 
 (options, args) = parser.parse_args()
 
@@ -199,6 +199,8 @@ if __name__ == "__main__":
     # Configure paths
     if options.rootsavedata is True:
         config.saveInRoot = True
+
+
 
     # set title if it wasn't supplied by argument
     if options.title is None:

--- a/pyfa.py
+++ b/pyfa.py
@@ -383,18 +383,20 @@ if __name__ == "__main__":
         pyfalog.info("Starting threads")
         executeStartupThreads()
 
-        from service.esi import esiUpdate
-
-        sESI = esiUpdate.getInstance()
-        sESI.updateTypes()
+        # from service.esi import esiUpdate
 
         '''
+        sESI = esiUpdate.getInstance()
+        sESI.updateTypes()
+        '''
+
+        # '''
         from gui.mainFrame import MainFrame
 
         pyfa = wx.App(False)
         MainFrame(options.title)
         pyfa.MainLoop()
-        '''
+        # '''
 
         # TODO: Add some thread cleanup code here. Right now we bail, and that can lead to orphaned threads or threads not properly exiting.
         sys.exit()

--- a/pyfa.py
+++ b/pyfa.py
@@ -176,6 +176,8 @@ parser.add_option("-d", "--debug", action="store_true", dest="debug", help="Set 
 parser.add_option("-t", "--title", action="store", dest="title", help="Set Window Title", default=None)
 parser.add_option("-s", "--savepath", action="store", dest="savepath", help="Set the folder for savedata", default=None)
 parser.add_option("-l", "--logginglevel", action="store", dest="logginglevel", help="Set desired logging level [Critical|Error|Warning|Info|Debug]", default="Error")
+parser.add_option("-esi", "--esiurl", action="store", dest="esiurl", help="Path to use for ESI.", default="https://esi.tech.ccp.is/latest/swagger.json?datasource=tranquility")
+parser.add_option("-gdb", "--gamedatadatabase", action="store", dest="gamedatadatabase", help="Name to use for the gamedata database", default="eve.db")
 
 (options, args) = parser.parse_args()
 
@@ -383,20 +385,11 @@ if __name__ == "__main__":
         pyfalog.info("Starting threads")
         executeStartupThreads()
 
-        # from service.esi import esiUpdate
-
-        '''
-        sESI = esiUpdate.getInstance()
-        sESI.updateTypes()
-        '''
-
-        # '''
         from gui.mainFrame import MainFrame
 
         pyfa = wx.App(False)
         MainFrame(options.title)
         pyfa.MainLoop()
-        # '''
 
         # TODO: Add some thread cleanup code here. Right now we bail, and that can lead to orphaned threads or threads not properly exiting.
         sys.exit()

--- a/pyfa.py
+++ b/pyfa.py
@@ -383,11 +383,18 @@ if __name__ == "__main__":
         pyfalog.info("Starting threads")
         executeStartupThreads()
 
+        from service.esi import esiUpdate
+
+        sESI = esiUpdate.getInstance()
+        sESI.updateTypes()
+
+        '''
         from gui.mainFrame import MainFrame
 
         pyfa = wx.App(False)
         MainFrame(options.title)
         pyfa.MainLoop()
+        '''
 
         # TODO: Add some thread cleanup code here. Right now we bail, and that can lead to orphaned threads or threads not properly exiting.
         sys.exit()

--- a/pyfa.py
+++ b/pyfa.py
@@ -177,7 +177,7 @@ parser.add_option("-t", "--title", action="store", dest="title", help="Set Windo
 parser.add_option("-s", "--savepath", action="store", dest="savepath", help="Set the folder for savedata", default=None)
 parser.add_option("-l", "--logginglevel", action="store", dest="logginglevel", help="Set desired logging level [Critical|Error|Warning|Info|Debug]", default="Error")
 parser.add_option("-e", "--esiurl", action="store", dest="esiurl", help="Path to use for ESI.", default="https://esi.tech.ccp.is/latest/swagger.json?datasource=tranquility")
-parser.add_option("-g", "--gamedatadatabase", action="store", dest="gamedatadatabase", help="Name to use for the gamedata database", default="eve.db")
+parser.add_option("-g", "--gamedatabasename", action="store", dest="gamedatabasename", help="Name to use for the gamedata database", default="eve.db")
 
 (options, args) = parser.parse_args()
 
@@ -200,7 +200,8 @@ if __name__ == "__main__":
     if options.rootsavedata is True:
         config.saveInRoot = True
 
-
+    config.esiurl = options.esiurl
+    config.gamedatabasename = options.gamedatabasename
 
     # set title if it wasn't supplied by argument
     if options.title is None:

--- a/pyfa.py
+++ b/pyfa.py
@@ -176,7 +176,8 @@ parser.add_option("-d", "--debug", action="store_true", dest="debug", help="Set 
 parser.add_option("-t", "--title", action="store", dest="title", help="Set Window Title", default=None)
 parser.add_option("-s", "--savepath", action="store", dest="savepath", help="Set the folder for savedata", default=None)
 parser.add_option("-l", "--logginglevel", action="store", dest="logginglevel", help="Set desired logging level [Critical|Error|Warning|Info|Debug]", default="Error")
-parser.add_option("-e", "--esiurl", action="store", dest="esiurl", help="Path to use for ESI.", default="https://esi.tech.ccp.is/latest/swagger.json?datasource=tranquility")
+parser.add_option("-e", "--esiurl", action="store", dest="esiurl", help="Path to use for ESI.",
+                  default="https://esi.tech.ccp.is/latest/swagger.json?datasource=tranquility")
 parser.add_option("-g", "--gamedatabasename", action="store", dest="gamedatabasename", help="Name to use for the gamedata database", default="eve.db")
 
 (options, args) = parser.parse_args()

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,7 @@ requests == 2.11.1
 sqlalchemy >= 1.0.5
 EVE_Gnosis
 multiprocess >= 0.70.5
+pyswagger
+six
+pytz
+esipy

--- a/service/esi.py
+++ b/service/esi.py
@@ -27,7 +27,7 @@ class esiConnection(object):
                 pool_maxsize=100,
         )
 
-        self.esi_app = App.create('https://esi.tech.ccp.is/latest/swagger.json?datasource=tranquility')
+        self.esi_app = App.create(config.esiurl)
         self.esi_client = EsiClient(
             headers={"User-Agent": "pyfa.fit_<3_snowedin"},
             retry_requests=True,
@@ -107,7 +107,7 @@ class esiMarket(object):
             row = results.first()
 
             if row is None:
-                query = u"INSERT INTO invmarketgroups (marketGroupID, marketGroupName, description, parentGroupID) VALUES ({0}, {1}, {2}, {3})".format(
+                query = u"INSERT INTO invmarketgroups (marketGroupID, marketGroupName, description, parentGroupID) VALUES ('{0}', '{1}', '{2}', '{3}')".format(
                     esi_market_group_id,
                     esi_market_group_name,
                     esi_market_group_description,

--- a/service/esi.py
+++ b/service/esi.py
@@ -1,0 +1,154 @@
+from esipy import App
+from esipy import EsiClient
+import eos.db
+from eos.db.saveddata.databaseRepair import DatabaseCleanup
+from eos.gamedata import Item
+from eos.db.gamedata import queries
+import collections
+
+# dogma_attributes = esi_app.op['get_dogma_attributes']()
+# attributes = esi_client.request(dogma_attributes)
+
+
+class esiUpdate(object):
+    instance = None
+
+    @classmethod
+    def getInstance(cls):
+        if cls.instance is None:
+            cls.instance = esiUpdate()
+
+        return cls.instance
+
+    def __init__(self):
+        self.esi_app = App.create('https://esi.tech.ccp.is/latest/swagger.json?datasource=tranquility')
+        self.esi_client = EsiClient()
+
+        self.gamedata_engine = eos.db.gamedata_engine
+
+    def updateTypes(self):
+        """
+        Main loop.
+        """
+        esi_universe_types_op = self.esi_app.op['get_universe_types']()
+        esi_universe_types = self.esi_client.request(esi_universe_types_op)
+
+        item_attribute_translation = {
+            "type_id": "ID",
+            "icon_id": "iconID",
+        }
+
+        for esi_type_id in esi_universe_types.data:
+            esi_universe_types_type_id_op = self.esi_app.op['get_universe_types_type_id'](
+                    type_id=esi_type_id,
+            )
+            esi_universe_types_type_id = self.esi_client.request(esi_universe_types_type_id_op)
+            esi_item = esi_universe_types_type_id.data
+
+            if esi_item:
+                try:
+                    esi_item_published = getattr(esi_item, "published", False)
+                    esi_item_name = getattr(esi_item, "name", None)
+                    esi_item_id = getattr(esi_item, "type_id", None)
+                except:
+                    # Missing name, ID, or not published, skip.
+                    continue
+
+                if not esi_item_id or not esi_item_published or not esi_item_name:
+                    # Missing name, ID, or not published, skip.
+                    continue
+
+                esiUpdate.process_invItems(esi_type_id)
+
+    @staticmethod
+    def add_update_query_item(update_query, attribute, value):
+        if attribute and value:
+            value = value.replace("'", "''")
+            update_query = "{0}, {1}='{2}'".format(update_query, attribute, value)
+            # make sure that we dont' have any commas hanging out on either side of our statement where they aren't supposed to be
+            update_query = update_query.lstrip(", ").rstrip(",")
+            return update_query
+        else:
+            return update_query
+
+    @staticmethod
+    def add_insert_query_item(columns_query, values_query, attribute, value):
+        if attribute and value:
+            if attribute == 'published':
+                # SQLite doesn't understand true/false, so set to 1/0
+                if value:
+                    value = 1
+                else:
+                    value = 0
+
+            try:
+                value = value.replace("'", "''")
+            except AttributeError:
+                # Not working with a string, that's okay. Skip.
+                pass
+
+            columns_query = columns_query.lstrip("(").rstrip(")")
+            columns_query = "{0}, {1}".format(columns_query, attribute)
+            columns_query = columns_query.lstrip(", ").rstrip(",")
+            columns_query = "({0})".format(columns_query)
+
+            values_query = values_query.lstrip("(").rstrip(")")
+            values_query = "{0}, '{1}'".format(values_query, value)
+            values_query = values_query.lstrip(", ").rstrip(",")
+            values_query = "({0})".format(values_query)
+
+            return columns_query, values_query
+        else:
+            return columns_query, values_query
+
+    def process_invItems(esi_type_id):
+        invtype_mapping = {
+            "capacity"     : "capacity",
+            "description"  : "description",
+            "factionID"    : None,
+            "groupID"      : "group_id",
+            "iconID"       : "icon_id",
+            "marketGroupID": None,
+            "mass"         : "mass",
+            "published"    : "published",
+            "raceID"       : None,
+            "typeName"     : "name",
+            "volume"       : "volume",
+        }
+
+        check_existance_query = "SELECT * FROM invTypes WHERE typeID = '%d'" % esi_type_id
+        check_existance_results = DatabaseCleanup.ExecuteSQLQuery(self.gamedata_engine, check_existance_query)
+        row = check_existance_results.first()
+
+        if row is None:
+            # It doesn't exist, create it.
+            column_query = "(typeID)"
+            values_query = "({0})".format(esi_type_id)
+
+            for map_item in invtype_mapping:
+                if invtype_mapping[map_item]:
+                    try:
+                        esi_item_attribute_value = esi_item[invtype_mapping[map_item]]
+                        if esi_item_attribute_value:
+                            column_query, values_query = add_insert_query_item(column_query, values_query, map_item, esi_item_attribute_value)
+                    except:
+                        pass
+
+            if column_query.__len__() > 0 and values_query.__len__() > 0:
+                update_query = "INSERT INTO invtypes {0} VALUES {1}".format(column_query, values_query)
+                DatabaseCleanup.ExecuteSQLQuery(self.gamedata_engine, update_query)
+        else:
+            update_query = ""
+
+            for map_item in invtype_mapping:
+                if invtype_mapping[map_item]:
+                    try:
+                        esi_item_attribute_value = esi_item[invtype_mapping[map_item]]
+                        if esi_item_attribute_value:
+                            update_query = add_update_query_item(update_query, map_item, esi_item_attribute_value)
+                    except:
+                        pass
+
+            if update_query.__len__() > 0:
+                update_query = "UPDATE invtypes SET {0} WHERE typeID = {1}".format(update_query, esi_type_id)
+                DatabaseCleanup.ExecuteSQLQuery(self.gamedata_engine, update_query)

--- a/service/esi.py
+++ b/service/esi.py
@@ -5,6 +5,10 @@ from eos.db.saveddata.databaseRepair import DatabaseCleanup
 from eos.gamedata import Item
 from eos.db.gamedata import queries
 import collections
+from logbook import Logger
+from itertools import chain
+
+pyfalog = Logger(__name__)
 
 # dogma_attributes = esi_app.op['get_dogma_attributes']()
 # attributes = esi_client.request(dogma_attributes)
@@ -22,48 +26,195 @@ class esiUpdate(object):
 
     def __init__(self):
         self.esi_app = App.create('https://esi.tech.ccp.is/latest/swagger.json?datasource=tranquility')
-        self.esi_client = EsiClient()
+        self.esi_client = EsiClient(
+            headers={"User-Agent": "pyfa.fit_<3_snowedin"},
+            retry_requests=True
+        )
 
         self.gamedata_engine = eos.db.gamedata_engine
+
+    def cleanMarketGroups(self, market_groups):
+        pyfalog.info("Removing all invalid market IDs")
+        query_list = ""
+        for market_group in market_groups:
+            query_list = self.add_query_list(query_list, market_group)
+        update_query = "UPDATE invtypes SET marketGroupID = NULL WHERE marketGroupID NOT IN ({0})".format(query_list)
+        query_results = DatabaseCleanup.ExecuteSQLQuery(self.gamedata_engine, update_query)
+        pyfalog.info("Removed incorrect Market Group ID from {0} items.", query_results.rowcount)
+
+    def fetchEsiMarketID(self):
+        esi_market_group_types_list = {}
+        pyfalog.info("Fetching market group list from ESI")
+        esi_request = self.esi_app.op['get_markets_groups']()
+        esi_market_groups = self.esi_client.request(esi_request).data
+
+        self.cleanMarketGroups(esi_market_groups)
+
+        pyfalog.info("Fetching market group items from ESI")
+        esi_market_group_types = self.esi_client.multi_request(
+                [self.esi_app.op["get_markets_groups_market_group_id"](market_group_id=x) for x in esi_market_groups],
+                threads=50,
+        )
+
+        esi_market_group_types_list = [x.data for x in [x[1] for x in esi_market_group_types]]
+
+        return esi_market_group_types_list
+
+    def updateTypesMarketGroup(self, market_list):
+        pyfalog.info("Updating items market group.")
+        for market_group in  market_list:
+            if market_group['types'].__len__() > 0:
+                query_list = ""
+                for market_group_type in market_group['types']:
+                    query_list = self.add_query_list(query_list, market_group_type)
+                update_query = "UPDATE invtypes SET marketGroupID = '{0}' WHERE typeID in ({1})".format(market_group['market_group_id'], query_list)
+                query_results = DatabaseCleanup.ExecuteSQLQuery(self.gamedata_engine, update_query)
+                pyfalog.debug("Added Market Group ID ({0}) to {1} items.", market_group['market_group_id'], query_results.rowcount)
+
+    def fetchEsiTypes(self):
+        esi_types_list = []
+        pyfalog.info("Fetching type_id list from ESI")
+        for _ in range(5000):
+            esi_universe_types_op = self.esi_app.op['get_universe_types'](
+                page=(_+1),
+            )
+            esi_universe_types = self.esi_client.request(esi_universe_types_op)
+            if esi_universe_types.data.__len__() == 0:
+                break
+
+            esi_types_list.extend(esi_universe_types.data)
+
+        return esi_types_list
 
     def updateTypes(self):
         """
         Main loop.
         """
-        esi_universe_types_op = self.esi_app.op['get_universe_types']()
-        esi_universe_types = self.esi_client.request(esi_universe_types_op)
+        pyfalog.info("Started updating items.")
+        setting_to_use_all_items = False
 
-        item_attribute_translation = {
-            "type_id": "ID",
-            "icon_id": "iconID",
-        }
+        esi_type_list = self.fetchEsiTypes()
 
-        for esi_type_id in esi_universe_types.data:
-            esi_universe_types_type_id_op = self.esi_app.op['get_universe_types_type_id'](
-                    type_id=esi_type_id,
-            )
-            esi_universe_types_type_id = self.esi_client.request(esi_universe_types_type_id_op)
-            esi_item = esi_universe_types_type_id.data
+        esi_market_group_types_list = self.fetchEsiMarketID()
+        esi_market_type_list = [i for i in chain.from_iterable([x['types'] for x in esi_market_group_types_list])]
+
+        if not setting_to_use_all_items:
+            esi_type_list = esi_market_type_list
+
+        self.clean_types(esi_type_list, esi_market_type_list)
+
+        esi_request = self.esi_app.op['get_markets_groups']()
+        esi_market_groups = self.esi_client.request(esi_request).data
+
+        self.cleanMarketGroups(esi_market_groups)
+
+        self.updateTypesData(esi_type_list)
+
+        self.updateTypesMarketGroup(esi_market_group_types_list)
+        pyfalog.info("Completed updating items.")
+
+    def updateTypesData(self, esi_type_list):
+        pyfalog.info("Fetching types from ESI.")
+        esi_universe_types_type_list = self.esi_client.multi_request(
+                [self.esi_app.op["get_universe_types_type_id"](type_id=x) for x in esi_type_list],
+                threads=50,
+        )
+
+        esi_universe_types_type_list = [x[1].data for x in esi_universe_types_type_list]
+
+        esi_types_with_dogma_attributes_list = [x.type_id for x in esi_universe_types_type_list if hasattr(x, 'dogma_attributes')]
+        esi_types_with_dogma_effects_list = [x.type_id for x in esi_universe_types_type_list if hasattr(x, 'dogma_effects')]
+        self.clean_types_dogma(esi_types_with_dogma_attributes_list, esi_types_with_dogma_effects_list)
+
+        pyfalog.info("Updating database with items.")
+        for esi_item in esi_universe_types_type_list:
 
             if esi_item:
                 try:
                     esi_item_published = getattr(esi_item, "published", False)
                     esi_item_name = getattr(esi_item, "name", None)
                     esi_item_id = getattr(esi_item, "type_id", None)
-                except:
+                except AttributeError:
+                    # Missing name, ID, or not published, skip.
+                    esi_item_published = False
+                    esi_item_name = None
+                    esi_item_id = None
+                    continue
+
+                if not esi_item_id or not esi_item_name:
                     # Missing name, ID, or not published, skip.
                     continue
 
-                if not esi_item_id or not esi_item_published or not esi_item_name:
-                    # Missing name, ID, or not published, skip.
-                    continue
+                setting_to_allow_published = True
+                if (setting_to_allow_published is True and esi_item_published is True) or setting_to_allow_published is False:
+                    self.process_invItems(esi_item_id, esi_item)
 
-                esiUpdate.process_invItems(esi_type_id)
+                try:
+                    if hasattr(esi_item, 'dogma_attributes'):
+                        esi_item_attributes = getattr(esi_item, 'dogma_attributes', None)
+                    else:
+                        esi_item_attributes = None
+                except AttributeError:
+                    esi_item_attributes = None
+
+                try:
+                    if hasattr(esi_item, 'dogma_effects'):
+                        esi_item_effects = getattr(esi_item, 'dogma_effects', None)
+                    else:
+                        esi_item_effects = None
+                except AttributeError:
+                    esi_item_effects = None
+
+                self.clean_item_dogma(esi_item_id, esi_item, esi_item_attributes, esi_item_effects)
+
+                if esi_item_attributes:
+                    count_insert = 0
+                    count_update = 0
+                    for esi_attribute in esi_item_attributes:
+                        query = "SELECT * FROM dgmtypeattribs WHERE typeID = '{0}' and attributeID = '{1}'".format(esi_item_id, esi_attribute['attribute_id'])
+                        results = DatabaseCleanup.ExecuteSQLQuery(self.gamedata_engine, query)
+                        row = results.first()
+
+                        if row is None:
+                            query = "INSERT INTO dgmtypeattribs (typeID, attributeID, value) VALUES ({0}, {1}, {2})".format(esi_item_id, esi_attribute['attribute_id'], esi_attribute['value'])
+                            DatabaseCleanup.ExecuteSQLQuery(self.gamedata_engine, query)
+                            count_insert += 1
+                        else:
+                            query = "UPDATE dgmtypeattribs SET value = '{0}' WHERE typeID = '{1}' and attributeID = '{2}'".format(esi_attribute['value'], esi_item_id, esi_attribute['attribute_id'])
+                            DatabaseCleanup.ExecuteSQLQuery(self.gamedata_engine, query)
+                            count_update += 1
+                    pyfalog.debug("For TypeID ({0}) updated {1} and added {2} attributes.", esi_item_id, count_update, count_insert)
+
+                if esi_item_effects:
+                    count_insert = 0
+                    for esi_effect in esi_item_effects:
+                        query = "SELECT * FROM dgmtypeeffects WHERE typeID = '{0}' and effectID = '{1}'".format(esi_item_id, esi_effect['effect_id'])
+                        results = DatabaseCleanup.ExecuteSQLQuery(self.gamedata_engine, query)
+                        row = results.first()
+
+                        if row is None:
+                            query = "INSERT INTO dgmtypeeffects (typeID, effectID) VALUES ({0}, {1})".format(esi_item_id, esi_effect['effect_id'])
+                            DatabaseCleanup.ExecuteSQLQuery(self.gamedata_engine, query)
+                            count_insert += 1
+                    pyfalog.debug("For TypeID ({0}) added {1} effects.", esi_item_id, count_insert)
 
     @staticmethod
     def add_update_query_item(update_query, attribute, value):
         if attribute and value:
+            if attribute == 'published':
+                # SQLite doesn't understand true/false, so set to 1/0
+                if value == "True" or value is True:
+                    value = 1
+                elif value == "False" or value is False:
+                    value = 0
+                else:
+                    # Unexpected value, so set to 0
+                    value = 0
+
+            # Set value to a string so we can perform string manipulations
+            value = str(value)
             value = value.replace("'", "''")
+
             update_query = "{0}, {1}='{2}'".format(update_query, attribute, value)
             # make sure that we dont' have any commas hanging out on either side of our statement where they aren't supposed to be
             update_query = update_query.lstrip(", ").rstrip(",")
@@ -72,20 +223,32 @@ class esiUpdate(object):
             return update_query
 
     @staticmethod
+    def add_query_list(update_query, value):
+        # Set value to a string so we can perform string manipulations
+        value = str(value)
+        value = value.replace("'", "''")
+
+        update_query = "{0}, '{1}'".format(update_query, value)
+        # make sure that we dont' have any commas hanging out on either side of our statement where they aren't supposed to be
+        update_query = update_query.lstrip(", ").rstrip(",")
+        return update_query
+
+    @staticmethod
     def add_insert_query_item(columns_query, values_query, attribute, value):
         if attribute and value:
             if attribute == 'published':
                 # SQLite doesn't understand true/false, so set to 1/0
-                if value:
+                if value == "True" or value is True:
                     value = 1
+                elif value == "False" or value is False:
+                    value = 0
                 else:
+                    # Unexpected value, so set to 0
                     value = 0
 
-            try:
-                value = value.replace("'", "''")
-            except AttributeError:
-                # Not working with a string, that's okay. Skip.
-                pass
+            # Set value to a string so we can perform string manipulations
+            value = str(value)
+            value = value.replace("'", "''")
 
             columns_query = columns_query.lstrip("(").rstrip(")")
             columns_query = "{0}, {1}".format(columns_query, attribute)
@@ -101,7 +264,7 @@ class esiUpdate(object):
         else:
             return columns_query, values_query
 
-    def process_invItems(esi_type_id):
+    def process_invItems(self, esi_type_id, esi_item):
         invtype_mapping = {
             "capacity"     : "capacity",
             "description"  : "description",
@@ -130,13 +293,14 @@ class esiUpdate(object):
                     try:
                         esi_item_attribute_value = esi_item[invtype_mapping[map_item]]
                         if esi_item_attribute_value:
-                            column_query, values_query = add_insert_query_item(column_query, values_query, map_item, esi_item_attribute_value)
-                    except:
+                            column_query, values_query = self.add_insert_query_item(column_query, values_query, map_item, esi_item_attribute_value)
+                    except Exception as e:
                         pass
 
             if column_query.__len__() > 0 and values_query.__len__() > 0:
                 update_query = "INSERT INTO invtypes {0} VALUES {1}".format(column_query, values_query)
                 DatabaseCleanup.ExecuteSQLQuery(self.gamedata_engine, update_query)
+                pyfalog.debug("Added TypeID ({0}) to the database.", esi_type_id)
         else:
             update_query = ""
 
@@ -145,10 +309,79 @@ class esiUpdate(object):
                     try:
                         esi_item_attribute_value = esi_item[invtype_mapping[map_item]]
                         if esi_item_attribute_value:
-                            update_query = add_update_query_item(update_query, map_item, esi_item_attribute_value)
-                    except:
+                            update_query = self.add_update_query_item(update_query, map_item, esi_item_attribute_value)
+                    except Exception as e:
                         pass
 
             if update_query.__len__() > 0:
                 update_query = "UPDATE invtypes SET {0} WHERE typeID = {1}".format(update_query, esi_type_id)
                 DatabaseCleanup.ExecuteSQLQuery(self.gamedata_engine, update_query)
+                pyfalog.debug("Updated TypeID ({0}) in the database.", esi_type_id)
+
+    def clean_types(self, esi_types, esi_market_types):
+        pyfalog.debug("Purging items that don't exist, and cleaning market groups.")
+
+        update_query = ""
+        for type in esi_types:
+            update_query = self.add_query_list(update_query, type)
+
+        update_market_query = ""
+        for type in esi_market_types:
+            update_market_query = self.add_query_list(update_market_query, type)
+
+        query = "SELECT typeID FROM invTypes"
+        results = DatabaseCleanup.ExecuteSQLQuery(self.gamedata_engine, query)
+        rows = results.fetchall()
+
+        query = "DELETE FROM invTypes WHERE typeID NOT IN ({0})".format(update_query)
+        query_results = DatabaseCleanup.ExecuteSQLQuery(self.gamedata_engine, query)
+        pyfalog.debug("Deleted {0} records out of invTypes", query_results.rowcount)
+
+        query = "UPDATE invTypes SET marketGroupID = NULL WHERE typeID NOT IN ({0})".format(update_market_query)
+        query_results = DatabaseCleanup.ExecuteSQLQuery(self.gamedata_engine, query)
+        pyfalog.debug("Set {0} records in invTypes to market group of null.", query_results.rowcount)
+
+    def clean_types_dogma(self, dogma_attributes_list, dogma_effects_list):
+        pyfalog.debug("Purging dogma attributes and effects from items that don't exist.")
+        if dogma_attributes_list:
+            update_query_list = ""
+            for dogma_attribute in dogma_attributes_list:
+                update_query_list = self.add_query_list(update_query_list, dogma_attribute)
+
+            query = "DELETE FROM dgmtypeattribs WHERE typeID NOT IN ({0})".format(update_query_list)
+            DatabaseCleanup.ExecuteSQLQuery(self.gamedata_engine, query)
+            pyfalog.debug("Cleaned obsolete records from dgmtypeattribs.")
+
+        if dogma_effects_list:
+            update_query_list = ""
+            for dogma_effect in dogma_effects_list:
+                update_query_list = self.add_query_list(update_query_list, dogma_effect)
+
+            query = "DELETE FROM dgmtypeeffects WHERE typeID NOT IN ({0})".format(dogma_effects_list)
+            DatabaseCleanup.ExecuteSQLQuery(self.gamedata_engine, query)
+            pyfalog.debug("vrecords from dgmtypeeffects.")
+
+    def clean_item_dogma(self, esi_item_id, esi_item, esi_item_attributes, esi_item_effects):
+        pyfalog.info("Cleaning dogma attributes and effects from items.")
+        if esi_item_attributes and esi_item_id:
+            esi_item_attributes_list = [x['attribute_id'] for x in esi_item['dogma_attributes']]
+
+            update_query_list = ""
+            for dogma_attribute in esi_item_attributes_list:
+                update_query_list = self.add_query_list(update_query_list, dogma_attribute)
+
+            query = "DELETE FROM dgmtypeattribs WHERE typeID = '{0}' AND attributeID NOT IN ({1})".format(esi_item_id, update_query_list)
+            DatabaseCleanup.ExecuteSQLQuery(self.gamedata_engine, query)
+            pyfalog.debug("Deleted records from dgmtypeattribs for item ({0}).", esi_item_id)
+
+        if esi_item_effects and esi_item_id:
+            esi_item_effects_list = [x['effect_id'] for x in esi_item['dogma_effects']]
+
+            update_query_list = ""
+            for dogma_effect in esi_item_effects_list:
+                update_query_list = self.add_query_list(update_query_list, dogma_effect)
+
+            query = "DELETE FROM dgmtypeeffects WHERE typeID = '{0}' AND effectID NOT IN ({1})".format(esi_item_id, update_query_list)
+            DatabaseCleanup.ExecuteSQLQuery(self.gamedata_engine, query)
+            pyfalog.debug("Deleted records from dgmtypeeffects for item ({0}).", esi_item_id)
+

--- a/service/esi.py
+++ b/service/esi.py
@@ -184,7 +184,6 @@ class esiItems(object):
         pyfalog.info("Started updating items.")
 
         trans = self.sESIConnection.gamedata_connection.begin()
-        setting_to_use_all_items = False
 
         esi_type_list = self.fetchEsiTypes()
 

--- a/service/esi.py
+++ b/service/esi.py
@@ -149,7 +149,7 @@ class esiItems(object):
             query_list = self.sESIHelpers.addQueryList(query_list, market_group)
         update_query = u"UPDATE invtypes SET marketGroupID = NULL WHERE marketGroupID NOT IN ({0})".format(query_list)
         query_results = DatabaseCleanup.ExecuteSQLQuery(self.sESIConnection.gamedata_connection, update_query)
-        pyfalog.info("Removed incorrect Market Group ID from {0} items.", query_results.rowcount)
+        pyfalog.debug("Removed incorrect Market Group ID from {0} items.", query_results.rowcount)
 
     def updateTypesMarketGroup(self, market_list):
         pyfalog.info("Updating items market group.")
@@ -654,7 +654,7 @@ class esiHelpers(object):
     def deleteBadRecords(self, table, attribute, value_list):
         query = u"DELETE FROM {0} WHERE {1} NOT IN ({2})".format(table, attribute, value_list)
         query_results = DatabaseCleanup.ExecuteSQLQuery(self.sESIConnection.gamedata_connection, query)
-        pyfalog.info("Deleted {0} records from {1}.", query_results.rowcount, table)
+        pyfalog.debug("Deleted {0} records from {1}.", query_results.rowcount, table)
 
     def addRecord(self, table, identifier, columns):
         """
@@ -709,7 +709,7 @@ class esiHelpers(object):
                         query_values,
                 )
                 DatabaseCleanup.ExecuteSQLQuery(self.sESIConnection.gamedata_connection, query)
-                pyfalog.info("Insert new record for ID ({0}) into {1}.", identifier, table)
+                pyfalog.debug("Insert new record for ID ({0}) into {1}.", identifier, table)
             else:
                 query_values = u""
                 for column in columns:

--- a/service/esi.py
+++ b/service/esi.py
@@ -258,7 +258,7 @@ class esiItems(object):
                         esi_item_attributes = getattr(esi_item, "dogma_attributes", None)
                     else:
                         esi_item_attributes = None
-                except:
+                except (AttributeError, KeyError):
                     pyfalog.warning("Failed to look up item attributes for item {0}.", esi_item_id)
                     esi_item_attributes = None
 
@@ -267,7 +267,7 @@ class esiItems(object):
                         esi_item_effects = getattr(esi_item, "dogma_effects", None)
                     else:
                         esi_item_effects = None
-                except:
+                except (AttributeError, KeyError):
                     pyfalog.warning("Failed to look up item effects for item {0}.", esi_item_id)
                     esi_item_effects = None
 
@@ -366,12 +366,12 @@ class esiItems(object):
         pyfalog.debug("Purging items that don't exist, and cleaning market groups.")
 
         update_query = u""
-        for type in esi_types:
-            update_query = self.sESIHelpers.addQueryList(update_query, type)
+        for esi_type in esi_types:
+            update_query = self.sESIHelpers.addQueryList(update_query, esi_type)
 
         update_market_query = u""
-        for type in esi_market_types:
-            update_market_query = self.sESIHelpers.addQueryList(update_market_query, type)
+        for esi_type in esi_market_types:
+            update_market_query = self.sESIHelpers.addQueryList(update_market_query, esi_type)
 
         query = u"DELETE FROM invTypes WHERE typeID NOT IN ({0})".format(update_query)
         query_results = DatabaseCleanup.ExecuteSQLQuery(self.sESIConnection.gamedata_connection, query)

--- a/service/market.py
+++ b/service/market.py
@@ -364,16 +364,23 @@ class Market(object):
             "Structure Module",
         )
         self.SEARCH_GROUPS = ("Ice Product",)
-        self.ROOT_MARKET_GROUPS = (9,  # Modules
-                                   1111,  # Rigs
-                                   157,  # Drones
-                                   11,  # Ammo
-                                   1112,  # Subsystems
-                                   24,  # Implants & Boosters
-                                   404,  # Deployables
-                                   2202,  # Structure Equipment
-                                   2203  # Structure Modifications
-                                   )
+
+        if self.generalSettings.get("showAllMarketGroups"):
+            marketGroups = eos.db.getAllMarketGroups()
+            self.ROOT_MARKET_GROUPS = [x.marketGroupID for x in marketGroups if x.parentGroupID == 'Null' and x.name not in ('Ships', 'Structures')]
+            self.ROOT_MARKET_GROUPS.append([x.marketGroupID for x in marketGroups if x.name == 'Deployable Structures' and x.parentGroupID == 477][0])
+        else:
+            self.ROOT_MARKET_GROUPS = (9,  # Modules
+                                       1111,  # Rigs
+                                       157,  # Drones
+                                       11,  # Ammo
+                                       1112,  # Subsystems
+                                       24,  # Implants & Boosters
+                                       404,  # Deployables
+                                       2202,  # Structure Equipment
+                                       2203  # Structure Modifications
+                                       )
+
         # Tell other threads that Market is at their service
         mktRdy.set()
 

--- a/service/market.py
+++ b/service/market.py
@@ -668,12 +668,13 @@ class Market(object):
         if vars_:
             parents = set()
             for item in baseitms:
-                # Add one of the base market group items to result
-                result.add(item)
-                parent = self.getParentItemByItem(item, selfparent=False)
-                # If item has no parent, it's base item (or at least should be)
-                if parent is None:
-                    parents.add(item)
+                if item:
+                    # Add one of the base market group items to result
+                    result.add(item)
+                    parent = self.getParentItemByItem(item, selfparent=False)
+                    # If item has no parent, it's base item (or at least should be)
+                    if parent is None:
+                        parents.add(item)
             # Fetch variations only for parent items
             variations = self.getVariationsByItems(parents, alreadyparent=True)
             for variation in variations:

--- a/service/settings.py
+++ b/service/settings.py
@@ -361,6 +361,7 @@ class GeneralSettings(object):
             "itemSearchLimit": 150,
             "marketSearchDelay": 250,
             "fontSize": 'NORMAL',
+            "showAllMarketGroups": False,
         }
 
         self.serviceGeneralDefaultSettings = SettingsProvider.getInstance().getSettings("pyfaGeneralSettings", GeneralDefaultSettings)

--- a/service/settings.py
+++ b/service/settings.py
@@ -373,6 +373,36 @@ class GeneralSettings(object):
         self.serviceGeneralDefaultSettings[type] = value
 
 
+class DatabaseSettings(object):
+    _instance = None
+
+    @classmethod
+    def getInstance(cls):
+        if cls._instance is None:
+            cls._instance = DatabaseSettings()
+
+        return cls._instance
+
+    def __init__(self):
+        # mode
+        # 0 - Do not show
+        # 1 - Minimal/Text Only View
+        # 2 - Full View
+        DatabaseDefaultSettings = {
+            "ImportItemsNotInMarketGroups": False,
+            "ImportItemsNotPublished": False,
+            "UpdateThreads": 25,
+        }
+
+        self.serviceDatabaseDefaultSettings = SettingsProvider.getInstance().getSettings("pyfaDatabaseSettings", DatabaseDefaultSettings)
+
+    def get(self, type):
+        return self.serviceDatabaseDefaultSettings[type]
+
+    def set(self, type, value):
+        self.serviceDatabaseDefaultSettings[type] = value
+
+
 class StatViewSettings(object):
     _instance = None
 


### PR DESCRIPTION
Grants the user the ability to update the database on demand.

To download SiSi database, it's recommended to make a _copy_ of your existing TQ database so you do not overwrite TQ data.  For this example, we will be setting this up to download SiSi data, but this can be done for other data sources as well (if they exist).
1. Open the directory where Pyfa is running from.
2. Create a copy of the existing game database `eve.db` and name it `eve_sisi.db`.
3. Create a shortcut of the Pyfa executable and in the target box after `pyfa.exe` add `--gamedatabasename eve_sisi.db --esiurl https://esi.tech.ccp.is/latest/swagger.json?datasource=singularity` (outside the quotes)
4. Launch Pyfa using the shortcut created (or via command line).
5. Open the `Preferences` window and navigate to `Database`.  Verify that the `Game Database` field correctly displays the database name specified in step 3.
6. Adjust the database update settings as desired.  With the default settings, it will typically take 15-20 minutes to update the database (depending on many factors including network and computer speed).  If you enable importing more items, the time will go up drastically.
7. Click `Update Database`
8. Wait while the database updates.  When the database update is complete, it will prompt you to restart Pyfa and close the application.  Remember to restart using the shortcut created in step 3.