### PR TITLE
Bugfix: Stacktrace when ship name has unicode chars

### DIFF
--- a/eos/saveddata/fit.py
+++ b/eos/saveddata/fit.py
@@ -731,7 +731,7 @@ class Fit(object):
         shadow = None
         projectionInfo = None
         if targetFit:
-            pyfalog.info("Calculating projections from {0} to target {1}", self.name, targetFit.name)
+            pyfalog.info(u"Calculating projections from {0} to target {1}", self.name, targetFit.name)
             projectionInfo = self.getProjectionInfo(targetFit.ID)
             pyfalog.debug("ProjectionInfo: {0}", projectionInfo)
             if self is targetFit:

--- a/gui/builtinContextMenus/commandFits.py
+++ b/gui/builtinContextMenus/commandFits.py
@@ -38,7 +38,7 @@ class CommandFits(ContextMenu):
         return "Command Fits"
 
     def addFit(self, menu, fit, includeShip=False):
-        label = fit.name if not includeShip else "({}) {}".format(fit.ship.item.name, fit.name)
+        label = fit.name if not includeShip else u"({}) {}".format(fit.ship.item.name, fit.name)
         id = ContextMenu.nextID()
         self.fitMenuItemIds[id] = fit
         menuItem = wx.MenuItem(menu, id, label)

--- a/gui/builtinContextMenus/tabbedFits.py
+++ b/gui/builtinContextMenus/tabbedFits.py
@@ -43,7 +43,7 @@ class TabbedFits(ContextMenu):
                 continue
             fit = sFit.getFit(page.activeFitID, basic=True)
             _id = ContextMenu.nextID()
-            mitem = wx.MenuItem(rootMenu, _id, '{}: {}'.format(fit.ship.item.name, fit.name))
+            mitem = wx.MenuItem(rootMenu, _id, u'{}: {}'.format(fit.ship.item.name, fit.name))
             bindmenu.Bind(wx.EVT_MENU, self.handleSelection, mitem)
             self.fitLookup[_id] = fit
             m.AppendItem(mitem)

--- a/gui/builtinViews/fittingView.py
+++ b/gui/builtinViews/fittingView.py
@@ -326,7 +326,7 @@ class FittingView(d.Display):
 
         if fit is not None:
             bitmap = BitmapLoader.getImage("race_%s_small" % fit.ship.item.race, "gui")
-            text = "%s: %s" % (fit.ship.item.name, fit.name)
+            text = u"%s: %s" % (fit.ship.item.name, fit.name)
 
             pageIndex = self.parent.GetPageIndex(self)
             if pageIndex is not None:

--- a/gui/graphFrame.py
+++ b/gui/graphFrame.py
@@ -248,8 +248,8 @@ class GraphFrame(wx.Frame):
                 self.subplot.plot(x, y)
                 legend.append(fit.name)
             except:
-                pyfalog.warning("Invalid values in '{0}'", fit.name)
-                self.SetStatusText("Invalid values in '%s'" % fit.name)
+                pyfalog.warning(u"Invalid values in '{0}'", fit.name)
+                self.SetStatusText(u"Invalid values in '%s'" % fit.name)
                 self.canvas.draw()
                 return
 

--- a/gui/mainFrame.py
+++ b/gui/mainFrame.py
@@ -417,7 +417,7 @@ class MainFrame(wx.Frame, IPortUser):
         """ Export active fit """
         sFit = Fit.getInstance()
         fit = sFit.getFit(self.getActiveFit())
-        defaultFile = "%s - %s.xml" % (fit.ship.item.name, fit.name) if fit else None
+        defaultFile = u"%s - %s.xml" % (fit.ship.item.name, fit.name) if fit else None
 
         dlg = wx.FileDialog(self, "Save Fitting As...",
                             wildcard="EVE XML fitting files (*.xml)|*.xml",

--- a/service/fit.py
+++ b/service/fit.py
@@ -139,7 +139,7 @@ class Fit(object):
         except ValueError:
             ship = es_Citadel(eos.db.getItem(shipID))
         fit = FitType(ship)
-        fit.name = name if name is not None else "New %s" % fit.ship.item.name
+        fit.name = name if name is not None else u"New %s" % fit.ship.item.name
         fit.damagePattern = self.pattern
         fit.targetResists = self.targetResists
         fit.character = self.character
@@ -1095,7 +1095,7 @@ class Fit(object):
 
     def recalc(self, fit, withBoosters=True, skipClear=False):
         start_time = time()
-        pyfalog.info("=" * 10 + "recalc: {0}" + "=" * 10, fit.name)
+        pyfalog.info(u"=" * 10 + u"recalc: {0}" + u"=" * 10, fit.name)
 
         if not skipClear:
             # Commit any changes before we recalc

--- a/service/port.py
+++ b/service/port.py
@@ -1114,7 +1114,7 @@ class Port(object):
             also, it's OK to arrange modules randomly?
         """
         offineSuffix = " /OFFLINE"
-        export = "[%s, %s]\n" % (fit.ship.item.name, fit.name)
+        export = u"[%s, %s]\n" % (fit.ship.item.name, fit.name)
         stuff = {}
         sFit = svcFit.getInstance()
         for module in fit.modules:


### PR DESCRIPTION
Should catch most instances when we would stacktrace due to unicode being in the ship name.