### PR TITLE
Builds: Fix bucket?

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,5 +57,5 @@ after_success:
   - ls /home/travis/build/Pyfa-fit/Pyfa-fit/
   - ls /home/travis/build/Pyfa-fit/Pyfa-fit/dist/pyfa
 addons:
-  artifacts: true
-  s3_region: "us-west-2"
+    artifacts:
+        s3_region: "us-west-2"


### PR DESCRIPTION
Attempt to fix bucket. Unfortunately, this has to be done by merging the PR as only branch builds (not PR builds) are allowed to upload to AWS, due to security reasons.