### PR TITLE
Bugfix: EVEMon Import broken due to missing security status

### DIFF
--- a/eos/saveddata/character.py
+++ b/eos/saveddata/character.py
@@ -119,7 +119,7 @@ class Character(object):
 
         return all0
 
-    def apiUpdateCharSheet(self, skills, secStatus):
+    def apiUpdateCharSheet(self, skills, secStatus=0):
         del self.__skills[:]
         self.__skillIdMap.clear()
         for skillRow in skills:

--- a/service/character.py
+++ b/service/character.py
@@ -77,6 +77,7 @@ class CharacterImportThread(threading.Thread):
                         pyfalog.error("Incorrect EVEMon XML sheet")
                         raise RuntimeError("Incorrect EVEMon XML sheet")
                     name = doc.getElementsByTagName("name")[0].firstChild.nodeValue
+                    securitystatus = doc.getElementsByTagName("securityStatus")[0].firstChild.nodeValue or 0
                     skill_els = doc.getElementsByTagName("skill")
                     skills = []
                     for skill in skill_els:
@@ -93,7 +94,7 @@ class CharacterImportThread(threading.Thread):
                                     skill.getAttribute("level"),
                             )
                     char = sCharacter.new(name + " (EVEMon)")
-                    sCharacter.apiUpdateCharSheet(char.ID, skills)
+                    sCharacter.apiUpdateCharSheet(char.ID, skills, securitystatus)
                 except Exception, e:
                     pyfalog.error("Exception on character import:")
                     pyfalog.error(e)
@@ -378,9 +379,9 @@ class Character(object):
         wx.CallAfter(guiCallback, e)
 
     @staticmethod
-    def apiUpdateCharSheet(charID, skills):
+    def apiUpdateCharSheet(charID, skills, securitystatus):
         char = eos.db.getCharacter(charID)
-        char.apiUpdateCharSheet(skills)
+        char.apiUpdateCharSheet(skills, securitystatus)
         eos.db.commit()
 
     @staticmethod


### PR DESCRIPTION
Fixes EVEMon import.  Security status was added, but wasn't handled in the EVEMon import.  Also, default secstatus to 0 if it's somehow missing.