### PR TITLE
Bugfix: Revert ID name change

### DIFF
--- a/gui/chromeTabs.py
+++ b/gui/chromeTabs.py
@@ -741,14 +741,14 @@ class PFAddRenderer(object):
 
 
 class PFTabsContainer(wx.Panel):
-    def __init__(self, parent, pos=(0, 0), size=(100, 22), init_id=wx.ID_ANY, canAdd=True):
+    def __init__(self, parent, pos=(0, 0), size=(100, 22), id=wx.ID_ANY, canAdd=True):
         """
         Defines the tab container. Handles functions such as tab selection and
         dragging, and defines minimum width of tabs (all tabs are of equal width,
         which is determined via widest tab). Also handles the tab preview, if any.
         """
 
-        wx.Panel.__init__(self, parent, init_id, pos, size)
+        wx.Panel.__init__(self, parent, id, pos, size)
         if wx.VERSION >= (3, 0):
             self.SetBackgroundStyle(wx.BG_STYLE_PAINT)
 
@@ -1384,7 +1384,7 @@ class PFNotebookPagePreview(wx.Frame):
         wx.Frame.__init__(
                 self,
                 parent,
-                init_id=wx.ID_ANY,
+                id=wx.ID_ANY,
                 title=wx.EmptyString,
                 pos=pos,
                 size=wx.DefaultSize,

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ python-dateutil
 urllib3
 requests == 2.11.1
 sqlalchemy >= 1.0.5
-EVE_Gnosis
+EVE_Gnosis >= 2017.6.27
 multiprocess >= 0.70.5
 pyswagger
 six >= 1.10.0


### PR DESCRIPTION
Reverts a rename to a parameter, as wx requires it to be named ID specifically.